### PR TITLE
Fix SIGSEGV crashes on 32-bit platforms (e.g. Raspberry Pi)

### DIFF
--- a/tcp/session.go
+++ b/tcp/session.go
@@ -18,6 +18,9 @@ import (
 type EventFunc func()
 
 type Session struct {
+	// This field needs to be the first in the struct to ensure proper word alignment on 32-bit platforms.
+	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	sequence              uint64
 	connection *coapNet.Conn
 
 	maxMessageSize                  int
@@ -29,7 +32,6 @@ type Session struct {
 	errors                          ErrorFunc
 	closeSocket                     bool
 
-	sequence              uint64
 	tokenHandlerContainer *HandlerContainer
 	midHandlerContainer   *HandlerContainer
 	handler               HandlerFunc

--- a/udp/client/clientconn.go
+++ b/udp/client/clientconn.go
@@ -36,6 +36,9 @@ type Session interface {
 
 // ClientConn represents a virtual connection to a conceptual endpoint, to perform COAPs commands.
 type ClientConn struct {
+	// This field needs to be the first in the struct to ensure proper word alignment on 32-bit platforms.
+	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	sequence              uint64
 	session                        Session
 	handler                        HandlerFunc
 	observationTokenHandler        *HandlerContainer
@@ -51,7 +54,6 @@ type ClientConn struct {
 
 	tokenHandlerContainer *HandlerContainer
 	midHandlerContainer   *HandlerContainer
-	sequence              uint64
 }
 
 // NewClientConn creates connection over session and observation.


### PR DESCRIPTION
On 32-bit platforms (e.g. Raspberry Pi) it is caller's responsibility to arrange 64-bit alignment of `sync/atomic` operation parameters, see: https://golang.org/pkg/sync/atomic/#pkg-note-BUG. This PR fixes `SIGSEGV: segmentation violation` errors on Raspberry Pi by moving struct members accessed using `sync/atomic` to the beginning of the struct where proper alignment is guaranteed by the runtime.

An example of SIGSEGV error that occurs without this fix:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11b20]

goroutine 1 [running]:
runtime/internal/atomic.goXadd64(0x2066094, 0x1, 0x0, 0x10000, 0x10)
        /usr/local/go/src/runtime/internal/atomic/atomic_arm.go:103 +0x1c
github.com/plgd-dev/go-coap/v2/udp/client.(*ClientConn).Sequence(...)
        /go/pkg/mod/github.com/plgd-dev/go-coap/v2@v2.1.0/udp/client/clientconn.go:466
github.com/plgd-dev/go-coap/v2/udp/client.(*ClientConn).Process(0x2066050, 0x2166000, 0x10, 0x10000, 0x200e118, 0x10001)
        /go/pkg/mod/github.com/plgd-dev/go-coap/v2@v2.1.0/udp/client/clientconn.go:479 +0xd0
github.com/plgd-dev/go-coap/v2/udp.(*Server).Serve(0x2121110, 0x212a420, 0x0, 0x0)
        /go/pkg/mod/github.com/plgd-dev/go-coap/v2@v2.1.0/udp/server.go:221 +0x1c4
```
