### PR TITLE
fix infinite loop caused by close connection during TLS handshake

### DIFF
--- a/net/conn.go
+++ b/net/conn.go
@@ -77,14 +77,15 @@ func (c *Conn) WriteWithContext(ctx context.Context, data []byte) error {
 			return ctx.Err()
 		default:
 		}
-		err := c.connection.SetWriteDeadline(time.Now().Add(c.heartBeat))
+		deadline := time.Now().Add(c.heartBeat)
+		err := c.connection.SetWriteDeadline(deadline)
 		if err != nil {
 			return fmt.Errorf("cannot set write deadline for connection: %w", err)
 		}
 		n, err := c.connection.Write(data[written:])
 
 		if err != nil {
-			if isTemporary(err) {
+			if isTemporary(err, deadline) {
 				continue
 			}
 			return fmt.Errorf("cannot write to connection: %w", err)
@@ -119,13 +120,14 @@ func (c *Conn) ReadWithContext(ctx context.Context, buffer []byte) (int, error) 
 		default:
 		}
 
-		err := c.connection.SetReadDeadline(time.Now().Add(c.heartBeat))
+		deadline := time.Now().Add(c.heartBeat)
+		err := c.connection.SetReadDeadline(deadline)
 		if err != nil {
 			return -1, fmt.Errorf("cannot set read deadline for connection: %w", err)
 		}
 		n, err := c.readBuffer.Read(buffer)
 		if err != nil {
-			if isTemporary(err) {
+			if isTemporary(err, deadline) {
 				continue
 			}
 			return -1, fmt.Errorf("cannot read from connection: %w", err)

--- a/net/dtlslistener.go
+++ b/net/dtlslistener.go
@@ -122,14 +122,15 @@ func (l *DTLSListener) AcceptWithContext(ctx context.Context) (net.Conn, error) 
 		if atomic.LoadUint32(&l.closed) == 1 {
 			return nil, ErrListenerIsClosed
 		}
-		err := l.SetDeadline(time.Now().Add(l.heartBeat))
+		deadline := time.Now().Add(l.heartBeat)
+		err := l.SetDeadline(deadline)
 		if err != nil {
 			return nil, fmt.Errorf("cannot set deadline to accept connection: %w", err)
 		}
 		rw, err := l.Accept()
 		if err != nil {
 			// check context in regular intervals and then resume listening
-			if isTemporary(err) {
+			if isTemporary(err, deadline) {
 				continue
 			}
 			return nil, fmt.Errorf("cannot accept connection: %w", err)

--- a/net/isTemporary.go
+++ b/net/isTemporary.go
@@ -3,12 +3,19 @@ package net
 import (
 	"net"
 	"strings"
+	"time"
 )
 
 // https://github.com/golang/go/blob/958e212db799e609b2a8df51cdd85c9341e7a404/src/internal/poll/fd.go#L43
 const ioTimeout = "i/o timeout"
 
-func isTemporary(err error) bool {
+func isTemporary(err error, deadline time.Time) bool {
+	if deadline.After(time.Now()) {
+		// when connection is closed during TLS handshake, it returns i/o timeout
+		// so we need to validate if timeout real occurs by set deadline otherwise infinite loop occurs.
+		return false
+	}
+
 	if netErr, ok := err.(net.Error); ok && (netErr.Temporary() || netErr.Timeout()) {
 		return true
 	}

--- a/net/isTemporary.go
+++ b/net/isTemporary.go
@@ -10,18 +10,22 @@ import (
 const ioTimeout = "i/o timeout"
 
 func isTemporary(err error, deadline time.Time) bool {
-	if deadline.After(time.Now()) {
-		// when connection is closed during TLS handshake, it returns i/o timeout
-		// so we need to validate if timeout real occurs by set deadline otherwise infinite loop occurs.
-		return false
-	}
-
-	if netErr, ok := err.(net.Error); ok && (netErr.Temporary() || netErr.Timeout()) {
-		return true
+	netErr, ok := err.(net.Error)
+	if ok {
+		if netErr.Timeout() {
+			// when connection is closed during TLS handshake, it returns i/o timeout
+			// so we need to validate if timeout real occurs by set deadline otherwise infinite loop occurs.
+			return deadline.Before(time.Now())
+		}
+		if netErr.Temporary() {
+			return true
+		}
 	}
 
 	if strings.Contains(err.Error(), ioTimeout) {
-		return true
+		// when connection is closed during TLS handshake, it returns i/o timeout
+		// so we need to validate if timeout real occurs by set deadline otherwise infinite loop occurs.
+		return deadline.Before(time.Now())
 	}
 	return false
 }

--- a/net/tcplistener.go
+++ b/net/tcplistener.go
@@ -66,14 +66,15 @@ func (l *TCPListener) AcceptWithContext(ctx context.Context) (net.Conn, error) {
 		if atomic.LoadUint32(&l.closed) == 1 {
 			return nil, ErrListenerIsClosed
 		}
-		err := l.SetDeadline(time.Now().Add(l.heartBeat))
+		deadline := time.Now().Add(l.heartBeat)
+		err := l.SetDeadline(deadline)
 		if err != nil {
 			return nil, fmt.Errorf("cannot set deadline to accept connection: %w", err)
 		}
 		rw, err := l.listener.Accept()
 		if err != nil {
 			// check context in regular intervals and then resume listening
-			if isTemporary(err) {
+			if isTemporary(err, deadline) {
 				continue
 			}
 			return nil, fmt.Errorf("cannot accept connection: %w", err)

--- a/net/tlslistener.go
+++ b/net/tlslistener.go
@@ -60,13 +60,14 @@ func (l *TLSListener) AcceptWithContext(ctx context.Context) (net.Conn, error) {
 		if atomic.LoadUint32(&l.closed) == 1 {
 			return nil, ErrListenerIsClosed
 		}
-		err := l.SetDeadline(time.Now().Add(l.heartBeat))
+		deadline := time.Now().Add(l.heartBeat)
+		err := l.SetDeadline(deadline)
 		if err != nil {
 			return nil, fmt.Errorf("cannot set deadline to accept connection: %w", err)
 		}
 		rw, err := l.listener.Accept()
 		if err != nil {
-			if isTemporary(err) {
+			if isTemporary(err, deadline) {
 				continue
 			}
 			return nil, fmt.Errorf("cannot accept connection: %w", err)


### PR DESCRIPTION
When connection is closed during TLS handshake, it returns i/o timeout.
So we need to validate if timeout real occurs by set deadline,
otherwise infinite loop occurs.