### PR TITLE
Deduplicate messages with the same message ID for UDP

### DIFF
--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -389,7 +389,7 @@ func (c *UDPConn) ReadWithContext(ctx context.Context, buffer []byte) (int, *net
 			if isTemporary(err, deadline) {
 				continue
 			}
-			return -1, nil, fmt.Errorf("cannot read from udp connection: %w", ctx.Err())
+			return -1, nil, fmt.Errorf("cannot read from udp connection: %w", err)
 		}
 		return n, s, err
 	}

--- a/udp/client/clientconn.go
+++ b/udp/client/clientconn.go
@@ -117,7 +117,8 @@ func (cc *ClientConn) do(req *pool.Message) (*pool.Message, error) {
 		return nil, fmt.Errorf("invalid token")
 	}
 
-	// MessageID & Type is set in cc.writeMessage below
+	req.SetMessageID(cc.getMID())
+	req.SetType(udpMessage.Confirmable)
 
 	respChan := make(chan *pool.Message, 1)
 	err := cc.tokenHandlerContainer.Insert(token, func(w *ResponseWriter, r *pool.Message) {

--- a/udp/client/mutexmap.go
+++ b/udp/client/mutexmap.go
@@ -1,0 +1,74 @@
+package client
+
+import (
+	"fmt"
+	"sync"
+)
+
+// MutexMap wraps a map of mutexes.  Each key locks separately.
+type MutexMap struct {
+	ml sync.Mutex                     // lock for entry map
+	ma map[interface{}]*mutexMapEntry // entry map
+}
+
+type mutexMapEntry struct {
+	m   *MutexMap   // point back to MutexMap, so we can synchronize removing this mutexMapEntry when cnt==0
+	el  sync.Mutex  // entry-specific lock
+	cnt int         // reference count
+	key interface{} // key in ma
+}
+
+// Unlocker provides an Unlock method to release the lock.
+type Unlocker interface {
+	Unlock()
+}
+
+// NewMutexMap returns an initalized MutexMap.
+func NewMutexMap() *MutexMap {
+	return &MutexMap{ma: make(map[interface{}]*mutexMapEntry)}
+}
+
+// Lock acquires a lock corresponding to this key.
+// This method will never return nil and Unlock() must be called
+// to release the lock when done.
+func (m *MutexMap) Lock(key interface{}) Unlocker {
+
+	// read or create entry for this key atomically
+	m.ml.Lock()
+	e, ok := m.ma[key]
+	if !ok {
+		e = &mutexMapEntry{m: m, key: key}
+		m.ma[key] = e
+	}
+	e.cnt++ // ref count
+	m.ml.Unlock()
+
+	// acquire lock, will block here until e.cnt==1
+	e.el.Lock()
+
+	return e
+}
+
+// Unlock releases the lock for this entry.
+func (entry *mutexMapEntry) Unlock() {
+
+	m := entry.m
+
+	// decrement and if needed remove entry atomically
+	m.ml.Lock()
+	e, ok := m.ma[entry.key]
+	if !ok { // entry must exist
+		m.ml.Unlock()
+		panic(fmt.Errorf("unlock requested for key=%v but no entry found", entry.key))
+	}
+	e.cnt--        // ref count
+	if e.cnt < 1 { // if it hits zero then we own it and remove from map
+		delete(m.ma, entry.key)
+	}
+	m.ml.Unlock()
+
+	// now that map stuff is handled, we unlock and let
+	// anything else waiting on this key through
+	e.el.Unlock()
+
+}

--- a/udp/client/mutexmap_test.go
+++ b/udp/client/mutexmap_test.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMutexMap(t *testing.T) {
+
+	r := rand.New(rand.NewSource(42))
+
+	m := NewMutexMap()
+	_ = m
+
+	keyCount := 20
+	iCount := 10000
+	out := make(chan string, iCount*2)
+
+	// run a bunch of concurrent requests for various keys,
+	// the idea is to have a lot of lock contention
+	var wg sync.WaitGroup
+	wg.Add(iCount)
+	for i := 0; i < iCount; i++ {
+		go func(rn int) {
+			defer wg.Done()
+			key := strconv.Itoa(rn)
+
+			// you can prove the test works by commenting the locking out and seeing it fail
+			l := m.Lock(key)
+			defer l.Unlock()
+
+			out <- key + " A"
+			time.Sleep(time.Microsecond) // make 'em wait a mo'
+			out <- key + " B"
+		}(r.Intn(keyCount))
+	}
+	wg.Wait()
+	close(out)
+
+	// verify the map is empty now
+	if l := len(m.ma); l != 0 {
+		t.Errorf("unexpected map length at test end: %v", l)
+	}
+
+	// confirm that the output always produced the correct sequence
+	outLists := make([][]string, keyCount)
+	for s := range out {
+		sParts := strings.Fields(s)
+		kn, err := strconv.Atoi(sParts[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		outLists[kn] = append(outLists[kn], sParts[1])
+	}
+	for kn := 0; kn < keyCount; kn++ {
+		l := outLists[kn] // list of output for this particular key
+		for i := 0; i < len(l); i += 2 {
+			if l[i] != "A" || l[i+1] != "B" {
+				t.Errorf("For key=%v and i=%v got unexpected values %v and %v", kn, i, l[i], l[i+1])
+				break
+			}
+		}
+	}
+	if t.Failed() {
+		t.Logf("Failed, outLists: %#v", outLists)
+	}
+
+}
+
+func BenchmarkM(b *testing.B) {
+	m := NewMutexMap()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// run uncontended lock/unlock - should be quite fast
+		m.Lock(i).Unlock()
+	}
+}


### PR DESCRIPTION
Fixes #156

As described in RFC 7252 4.5. Message Deduplication

- Handlers are only called once per received message id
- Responses are cached for EXCHANGE_LIFETIME = 247s (due to RFC 7252)
- Parallel handling of the same message ID is avoided to ensure propper caching
- Removed redundant setting of message ID and Type in func (cc *ClientConn) do(...)
- Fixed an error formatting mistake in connUDP.go