### PR TITLE
Allow client to send non-confirmable messages

### DIFF
--- a/message/pool/message.go
+++ b/message/pool/message.go
@@ -279,6 +279,10 @@ func (r *Message) IsModified() bool {
 	return r.isModified
 }
 
+func (r *Message) SetModified(b bool) {
+	r.isModified = b
+}
+
 func (r *Message) String() string {
 	return r.msg.String()
 }

--- a/mux/message.go
+++ b/mux/message.go
@@ -7,4 +7,9 @@ type Message struct {
 	*message.Message
 	// SequenceNumber identifies the order of the message from a TCP connection. For UDP it is just for debugging.
 	SequenceNumber uint64
+	// IsConfirmable indicates that a UDP message is confirmable. For TCP the value has no semantic.
+	// When a handler blocks a confirmable message, the client might decide to issue a re-transmission.
+	// Long running handlers can be handled in a go routine and send the response via w.Client().
+	// The ACK is sent as soon as the handler returns.
+	IsConfirmable bool
 }

--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	udpPool "github.com/plgd-dev/go-coap/v2/udp/message/pool"
 	"io"
 	"sync"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/plgd-dev/go-coap/v2/message"
 	"github.com/plgd-dev/go-coap/v2/message/codes"
+	udpMessage "github.com/plgd-dev/go-coap/v2/udp/message"
 )
 
 // Block Opion value is represented: https://tools.ietf.org/html/rfc7959#section-2.2
@@ -114,6 +114,13 @@ type Message interface {
 	SetBody(r io.ReadSeeker)
 	SetSequence(uint64)
 	String() string
+}
+
+// hasType enables access to message.Type for supported messages
+// Since only UDP messages have a type
+type hasType interface {
+	Type() udpMessage.Type
+	SetType(t udpMessage.Type)
 }
 
 // EncodeBlockOption encodes block values to coap option.
@@ -216,8 +223,8 @@ func bufferSize(szx SZX, maxMessageSize int) int64 {
 }
 
 func setTypeFrom(to Message, from Message) {
-	if udpTo, ok := to.(*udpPool.Message); ok {
-		if udpFrom, ok := from.(*udpPool.Message); ok {
+	if udpTo, ok := to.(hasType); ok {
+		if udpFrom, ok := from.(hasType); ok {
 			udpTo.SetType(udpFrom.Type())
 		}
 	}

--- a/net/blockwise/blockwise_test.go
+++ b/net/blockwise/blockwise_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dsnet/golib/memfile"
 	"github.com/plgd-dev/go-coap/v2/message"
 	"github.com/plgd-dev/go-coap/v2/message/codes"
+	udpMessage "github.com/plgd-dev/go-coap/v2/udp/message"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -164,6 +165,13 @@ func (r *testmessage) BodySize() (int64, error) {
 		return 0, err
 	}
 	return size, nil
+}
+
+func (r *testmessage) Type() udpMessage.Type {
+	return udpMessage.Confirmable
+}
+
+func (r *testmessage) SetType(t udpMessage.Type) {
 }
 
 func acquireMessage(ctx context.Context) Message {

--- a/udp/client/mux.go
+++ b/udp/client/mux.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	udp "github.com/plgd-dev/go-coap/v2/udp/message"
 	"io"
 
 	"github.com/plgd-dev/go-coap/v2/message"
@@ -21,6 +22,7 @@ func HandlerFuncToMux(m mux.Handler) HandlerFunc {
 		m.ServeCOAP(muxw, &mux.Message{
 			Message:        muxr,
 			SequenceNumber: r.Sequence(),
+			IsConfirmable:  r.Type() == udp.Confirmable,
 		})
 	}
 	return h

--- a/udp/client/mux.go
+++ b/udp/client/mux.go
@@ -1,12 +1,12 @@
 package client
 
 import (
-	udp "github.com/plgd-dev/go-coap/v2/udp/message"
 	"io"
 
 	"github.com/plgd-dev/go-coap/v2/message"
 	"github.com/plgd-dev/go-coap/v2/message/codes"
 	"github.com/plgd-dev/go-coap/v2/mux"
+	udpMessage "github.com/plgd-dev/go-coap/v2/udp/message"
 	"github.com/plgd-dev/go-coap/v2/udp/message/pool"
 )
 
@@ -22,7 +22,7 @@ func HandlerFuncToMux(m mux.Handler) HandlerFunc {
 		m.ServeCOAP(muxw, &mux.Message{
 			Message:        muxr,
 			SequenceNumber: r.Sequence(),
-			IsConfirmable:  r.Type() == udp.Confirmable,
+			IsConfirmable:  r.Type() == udpMessage.Confirmable,
 		})
 	}
 	return h

--- a/udp/message/pool/message.go
+++ b/udp/message/pool/message.go
@@ -66,6 +66,11 @@ func (r *Message) IsModified() bool {
 	return r.isModified || r.Message.IsModified()
 }
 
+func (r *Message) SetModified(b bool) {
+	r.isModified = b
+	r.Message.SetModified(b)
+}
+
 func (r *Message) Unmarshal(data []byte) (int, error) {
 	r.Reset()
 	if len(r.rawData) < len(data) {

--- a/udp/message/type.go
+++ b/udp/message/type.go
@@ -5,6 +5,8 @@ import (
 )
 
 // Type represents the message type.
+// It's only part of CoAP UDP messages.
+// Reliable transports like TCP do not have a type.
 type Type uint8
 
 const (


### PR DESCRIPTION
Fixes #191

- Non-confirmable requests are getting Non-confirmable responses by default
- Mux Message has IsConfirmable field for handler
- Blockwise transfer is keeping UDP message types
- ClientConn midHandlerContainer is only used for CON messages
- Non-confirmable requests are never re-transmitted
- The default type for new messages is Confirmable for backwards compatibility
- Added related testcases and asserts