### PR TITLE
Allow to set UDP ClientConn timing parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/pion/dtls/v2 v2.0.1-0.20200503085337-8e86b3a7d585
 	github.com/plgd-dev/kit v0.0.0-20200819113605-d5fcf3e94f63
 	github.com/stretchr/testify v1.5.1
+	go.uber.org/atomic v1.6.0
 	golang.org/x/net v0.0.0-20200506145744-7e3656a0809f
 )
 

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=

--- a/udp/client/clientconn.go
+++ b/udp/client/clientconn.go
@@ -59,6 +59,18 @@ type ClientConn struct {
 	midHandlerContainer   *HandlerContainer
 }
 
+func (cc *ClientConn) SetTransmissionNStart(d time.Duration) {
+	cc.transmissionNStart = d
+}
+
+func (cc *ClientConn) SetTransmissionAcknowledgeTimeout(d time.Duration) {
+	cc.transmissionAcknowledgeTimeout = d
+}
+
+func (cc *ClientConn) SetTransmissionMaxRetransmit(d int) {
+	cc.transmissionMaxRetransmit = d
+}
+
 // NewClientConn creates connection over session and observation.
 func NewClientConn(
 	session Session,


### PR DESCRIPTION
Fixes #180 

Adds SetTransmissionNStart, SetTransmissionAcknowledgeTimeout, SetTransmissionMaxRetransmit

It's not threadsafe, do we needs an additional Mutex and "safe" methods for using the values?