### PR TITLE
Remove goroutine for inactive monitor

### DIFF
--- a/dtls/client_test.go
+++ b/dtls/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -647,6 +648,9 @@ func TestClientConn_HandeShakeFailure(t *testing.T) {
 
 func TestClient_InactiveMonitor(t *testing.T) {
 	inactivityDetected := false
+	defer func() {
+		runtime.GC()
+	}()
 
 	srvCtx, srvCancel := context.WithTimeout(context.Background(), time.Second*3600)
 	defer srvCancel()

--- a/dtls/options.go
+++ b/dtls/options.go
@@ -122,17 +122,21 @@ func WithKeepAlive(keepalive *keepalive.KeepAlive) KeepAliveOpt {
 
 // InactivityMonitorOpt notifies when a connection was inactive for a given duration.
 type InactivityMonitorOpt struct {
-	inactivityMonitor inactivity.Monitor
+	duration   time.Duration
+	onInactive inactivity.OnInactiveFunc
 }
 
 func (o InactivityMonitorOpt) apply(opts *serverOptions) {
-	opts.inactivityMonitor = o.inactivityMonitor
+	opts.createInactivityMonitor = func() inactivity.Monitor {
+		return inactivity.NewInactivityMonitor(o.duration, o.onInactive)
+	}
 }
 
-// WithInactivityMonitor set deadline's for read/write operations over client connection.
-func WithInactivityMonitor(interval time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
+// WithInactivityMonitor set deadline's for read operations over client connection.
+func WithInactivityMonitor(duration time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
 	return InactivityMonitorOpt{
-		inactivityMonitor: inactivity.NewInactivityMonitor(interval, onInactive),
+		duration:   duration,
+		onInactive: onInactive,
 	}
 }
 

--- a/dtls/options.go
+++ b/dtls/options.go
@@ -132,6 +132,12 @@ func (o InactivityMonitorOpt) apply(opts *serverOptions) {
 	}
 }
 
+func (o InactivityMonitorOpt) applyDial(opts *dialOptions) {
+	opts.createInactivityMonitor = func() inactivity.Monitor {
+		return inactivity.NewInactivityMonitor(o.duration, o.onInactive)
+	}
+}
+
 // WithInactivityMonitor set deadline's for read operations over client connection.
 func WithInactivityMonitor(duration time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
 	return InactivityMonitorOpt{

--- a/dtls/server_test.go
+++ b/dtls/server_test.go
@@ -221,6 +221,8 @@ func TestServer_InactiveMonitor(t *testing.T) {
 	err = cc.Ping(ctx)
 	require.NoError(t, err)
 
+	time.Sleep(time.Millisecond * 300)
+
 	cc.Close()
 
 	checkCloseWg.Wait()

--- a/net/conn.go
+++ b/net/conn.go
@@ -44,9 +44,11 @@ func NewConn(c net.Conn, opts ...ConnOption) *Conn {
 		o.applyConn(&cfg)
 	}
 	connection := Conn{
-		connection: c,
-		heartBeat:  cfg.heartBeat,
-		readBuffer: bufio.NewReaderSize(c, 2048),
+		connection:     c,
+		heartBeat:      cfg.heartBeat,
+		readBuffer:     bufio.NewReaderSize(c, 2048),
+		onReadTimeout:  cfg.onReadTimeout,
+		onWriteTimeout: cfg.onWriteTimeout,
 	}
 	return &connection
 }

--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -181,8 +181,15 @@ func NewUDPConn(network string, c *net.UDPConn, opts ...UDPOption) *UDPConn {
 		packetConn = newPacketConnIPv4(ipv4.NewPacketConn(c))
 	}
 
-	connection := UDPConn{network: network, connection: c, heartBeat: cfg.heartBeat, packetConn: packetConn, errors: cfg.errors}
-	return &connection
+	return &UDPConn{
+		network:        network,
+		connection:     c,
+		heartBeat:      cfg.heartBeat,
+		packetConn:     packetConn,
+		errors:         cfg.errors,
+		onReadTimeout:  cfg.onReadTimeout,
+		onWriteTimeout: cfg.onWriteTimeout,
+	}
 }
 
 // LocalAddr returns the local network address. The Addr returned is shared by all invocations of LocalAddr, so do not modify it.

--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -16,11 +16,13 @@ import (
 //
 // Multiple goroutines may invoke methods on a UDPConn simultaneously.
 type UDPConn struct {
-	heartBeat  time.Duration
-	connection *net.UDPConn
-	packetConn packetConn
-	errors     func(err error)
-	network    string
+	heartBeat      time.Duration
+	connection     *net.UDPConn
+	packetConn     packetConn
+	errors         func(err error)
+	network        string
+	onReadTimeout  func() error
+	onWriteTimeout func() error
 
 	lock sync.Mutex
 }
@@ -146,57 +148,10 @@ var defaultUDPConnOptions = udpConnOptions{
 }
 
 type udpConnOptions struct {
-	heartBeat time.Duration
-	errors    func(err error)
-}
-
-// A UDPOption sets options such as heartBeat, errors parameters, etc.
-type UDPOption interface {
-	applyUDP(*udpConnOptions)
-}
-
-type heartBeat struct {
-	heartBeat time.Duration
-}
-
-func (h heartBeat) applyUDP(o *udpConnOptions) {
-	o.heartBeat = h.heartBeat
-}
-
-func (h heartBeat) applyConn(o *connOptions) {
-	o.heartBeat = h.heartBeat
-}
-
-func (h heartBeat) applyTCPListener(o *tcpListenerOptions) {
-	o.heartBeat = h.heartBeat
-}
-
-func (h heartBeat) applyTLSListener(o *tlsListenerOptions) {
-	o.heartBeat = h.heartBeat
-}
-
-func (h heartBeat) applyDTLSListener(o *dtlsListenerOptions) {
-	o.heartBeat = h.heartBeat
-}
-
-func WithHeartBeat(v time.Duration) heartBeat {
-	return heartBeat{
-		heartBeat: v,
-	}
-}
-
-type errorsOpt struct {
-	errors func(err error)
-}
-
-func (h errorsOpt) applyUDP(o *udpConnOptions) {
-	o.errors = h.errors
-}
-
-func WithErrors(v func(err error)) errorsOpt {
-	return errorsOpt{
-		errors: v,
-	}
+	heartBeat      time.Duration
+	errors         func(err error)
+	onReadTimeout  func() error
+	onWriteTimeout func() error
 }
 
 func NewListenUDP(network, addr string, opts ...UDPOption) (*UDPConn, error) {
@@ -326,6 +281,12 @@ LOOP:
 			err = c.writeToAddr(deadline, hopLimit, iface, ifaceAddr, port, raddr, buffer)
 			if err != nil {
 				if isTemporary(err, deadline) {
+					if c.onWriteTimeout != nil {
+						err := c.onWriteTimeout()
+						if err != nil {
+							return fmt.Errorf("cannot write multicast to %v: on timeout returns error: %w", iface.Name, err)
+						}
+					}
 					continue LOOP
 				}
 				if c.errors != nil {
@@ -360,6 +321,12 @@ func (c *UDPConn) WriteWithContext(ctx context.Context, raddr *net.UDPAddr, buff
 		n, err := WriteToUDP(c.connection, raddr, buffer[written:])
 		if err != nil {
 			if isTemporary(err, deadline) {
+				if c.onWriteTimeout != nil {
+					err := c.onWriteTimeout()
+					if err != nil {
+						return fmt.Errorf("cannot write to udp connection: on timeout returns error: %w", err)
+					}
+				}
 				continue
 			}
 			return fmt.Errorf("cannot write to udp connection: %w", err)
@@ -387,6 +354,12 @@ func (c *UDPConn) ReadWithContext(ctx context.Context, buffer []byte) (int, *net
 		if err != nil {
 			// check context in regular intervals and then resume listening
 			if isTemporary(err, deadline) {
+				if c.onReadTimeout != nil {
+					err := c.onReadTimeout()
+					if err != nil {
+						return -1, nil, fmt.Errorf("cannot read from udp connection: on timeout returns error: %w", err)
+					}
+				}
 				continue
 			}
 			return -1, nil, fmt.Errorf("cannot read from udp connection: %w", err)

--- a/net/options.go
+++ b/net/options.go
@@ -1,0 +1,120 @@
+package net
+
+import "time"
+
+// A UDPOption sets options such as heartBeat, errors parameters, etc.
+type UDPOption interface {
+	applyUDP(*udpConnOptions)
+}
+
+type HeartBeatOpt struct {
+	heartBeat time.Duration
+}
+
+func (h HeartBeatOpt) applyUDP(o *udpConnOptions) {
+	o.heartBeat = h.heartBeat
+}
+
+func (h HeartBeatOpt) applyConn(o *connOptions) {
+	o.heartBeat = h.heartBeat
+}
+
+func (h HeartBeatOpt) applyTCPListener(o *tcpListenerOptions) {
+	o.heartBeat = h.heartBeat
+}
+
+func (h HeartBeatOpt) applyTLSListener(o *tlsListenerOptions) {
+	o.heartBeat = h.heartBeat
+}
+
+func (h HeartBeatOpt) applyDTLSListener(o *dtlsListenerOptions) {
+	o.heartBeat = h.heartBeat
+}
+
+func WithHeartBeat(v time.Duration) HeartBeatOpt {
+	return HeartBeatOpt{
+		heartBeat: v,
+	}
+}
+
+type ErrorsOpt struct {
+	errors func(err error)
+}
+
+func (h ErrorsOpt) applyUDP(o *udpConnOptions) {
+	o.errors = h.errors
+}
+
+func WithErrors(v func(err error)) ErrorsOpt {
+	return ErrorsOpt{
+		errors: v,
+	}
+}
+
+type OnTimeoutOpt struct {
+	onTimeout func() error
+}
+
+func WithOnTimeout(onTimeout func() error) OnTimeoutOpt {
+	return OnTimeoutOpt{
+		onTimeout: onTimeout,
+	}
+}
+
+func (h OnTimeoutOpt) applyConn(o *connOptions) {
+	o.onReadTimeout = h.onTimeout
+	o.onWriteTimeout = h.onTimeout
+}
+
+func (h OnTimeoutOpt) applyUDP(o *udpConnOptions) {
+	o.onReadTimeout = h.onTimeout
+	o.onWriteTimeout = h.onTimeout
+}
+
+func (h OnTimeoutOpt) applyTCPListener(o *tcpListenerOptions) {
+	o.onTimeout = h.onTimeout
+}
+
+func (h OnTimeoutOpt) applyTLSListener(o *tlsListenerOptions) {
+	o.onTimeout = h.onTimeout
+}
+
+func (h OnTimeoutOpt) applyDTLSListener(o *dtlsListenerOptions) {
+	o.onTimeout = h.onTimeout
+}
+
+type OnReadTimeoutOpt struct {
+	onReadTimeout func() error
+}
+
+func WithOnReadTimeout(onReadTimeout func() error) OnReadTimeoutOpt {
+	return OnReadTimeoutOpt{
+		onReadTimeout: onReadTimeout,
+	}
+}
+
+func (h OnReadTimeoutOpt) applyConn(o *connOptions) {
+	o.onReadTimeout = h.onReadTimeout
+}
+
+func (h OnReadTimeoutOpt) applyUDP(o *udpConnOptions) {
+	o.onReadTimeout = h.onReadTimeout
+}
+
+type OnWriteTimeoutOpt struct {
+	onWriteTimeout func() error
+}
+
+func WithOnWriteTimeout(onWriteTimeout func() error) OnWriteTimeoutOpt {
+	return OnWriteTimeoutOpt{
+		onWriteTimeout: onWriteTimeout,
+	}
+}
+
+func (h OnWriteTimeoutOpt) applyConn(o *connOptions) {
+	o.onWriteTimeout = h.onWriteTimeout
+}
+
+func (h OnWriteTimeoutOpt) applyUDP(o *udpConnOptions) {
+	o.onWriteTimeout = h.onWriteTimeout
+}

--- a/net/tcplistener.go
+++ b/net/tcplistener.go
@@ -13,6 +13,7 @@ type TCPListener struct {
 	listener  *net.TCPListener
 	heartBeat time.Duration
 	closed    uint32
+	onTimeout func() error
 }
 
 func newNetTCPListen(network string, addr string) (*net.TCPListener, error) {
@@ -34,6 +35,7 @@ var defaultTCPListenerOptions = tcpListenerOptions{
 
 type tcpListenerOptions struct {
 	heartBeat time.Duration
+	onTimeout func() error
 }
 
 // A TCPListenerOption sets options such as heartBeat parameters, etc.
@@ -52,7 +54,7 @@ func NewTCPListener(network string, addr string, opts ...TCPListenerOption) (*TC
 	if err != nil {
 		return nil, fmt.Errorf("cannot create new tcp listener: %w", err)
 	}
-	return &TCPListener{listener: tcp, heartBeat: cfg.heartBeat}, nil
+	return &TCPListener{listener: tcp, heartBeat: cfg.heartBeat, onTimeout: cfg.onTimeout}, nil
 }
 
 // AcceptWithContext waits with context for a generic Conn.
@@ -75,6 +77,12 @@ func (l *TCPListener) AcceptWithContext(ctx context.Context) (net.Conn, error) {
 		if err != nil {
 			// check context in regular intervals and then resume listening
 			if isTemporary(err, deadline) {
+				if l.onTimeout != nil {
+					err := l.onTimeout()
+					if err != nil {
+						return nil, fmt.Errorf("cannot accept connection : on timeout returns error: %w", err)
+					}
+				}
 				continue
 			}
 			return nil, fmt.Errorf("cannot accept connection: %w", err)

--- a/tcp/clientconn.go
+++ b/tcp/clientconn.go
@@ -69,12 +69,17 @@ type DialOption interface {
 	applyDial(*dialOptions)
 }
 
+type Notifier interface {
+	Notify()
+}
+
 // ClientConn represents a virtual connection to a conceptual endpoint, to perform COAPs commands.
 type ClientConn struct {
 	noCopy
 	session                 *Session
 	observationTokenHandler *HandlerContainer
 	observationRequests     *kitSync.Map
+	activityMonitor         Notifier
 }
 
 // Dial creates a client connection to the given target.
@@ -165,6 +170,7 @@ func Client(conn net.Conn, opts ...DialOption) *ClientConn {
 		cfg.disablePeerTCPSignalMessageCSMs,
 		cfg.disableTCPSignalMessageCSM,
 		cfg.closeSocket,
+		nil,
 	)
 	cc := NewClientConn(session, observationTokenHandler, observationRequests)
 

--- a/tcp/clientconn_test.go
+++ b/tcp/clientconn_test.go
@@ -3,6 +3,7 @@ package tcp
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"io"
 	"io/ioutil"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/plgd-dev/go-coap/v2/mux"
+	"github.com/plgd-dev/go-coap/v2/net/monitor/inactivity"
 
 	"github.com/plgd-dev/go-coap/v2/message"
 	"github.com/plgd-dev/go-coap/v2/message/codes"
@@ -477,4 +479,67 @@ func TestClientConn_Ping(t *testing.T) {
 	defer cancel()
 	err = cc.Ping(ctx)
 	require.NoError(t, err)
+}
+
+func TestClient_InactiveMonitor(t *testing.T) {
+	inactivityDetected := false
+
+	ld, err := coapNet.NewTCPListener("tcp", "")
+	require.NoError(t, err)
+	defer ld.Close()
+
+	var checkCloseWg sync.WaitGroup
+	defer checkCloseWg.Wait()
+	sd := NewServer(
+		WithOnNewClientConn(func(cc *ClientConn, tlscon *tls.Conn) {
+			checkCloseWg.Add(1)
+			cc.AddOnClose(func() {
+				checkCloseWg.Done()
+			})
+		}),
+		WithKeepAlive(nil),
+	)
+
+	var serverWg sync.WaitGroup
+	defer func() {
+		sd.Stop()
+		serverWg.Wait()
+	}()
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		err := sd.Serve(ld)
+		require.NoError(t, err)
+	}()
+
+	cc, err := Dial(
+		ld.Addr().String(),
+		WithKeepAlive(nil),
+		WithInactivityMonitor(100*time.Millisecond, func(cc inactivity.ClientConn) {
+			require.False(t, inactivityDetected)
+			inactivityDetected = true
+			cc.Close()
+		}),
+	)
+	require.NoError(t, err)
+	checkCloseWg.Add(1)
+	cc.AddOnClose(func() {
+		checkCloseWg.Done()
+	})
+
+	// send ping to create serverside connection
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = cc.Ping(ctx)
+	require.NoError(t, err)
+
+	err = cc.Ping(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond * 300)
+
+	cc.Close()
+
+	checkCloseWg.Wait()
+	require.True(t, inactivityDetected)
 }

--- a/tcp/clientconn_test.go
+++ b/tcp/clientconn_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"io"
 	"io/ioutil"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -483,6 +484,9 @@ func TestClientConn_Ping(t *testing.T) {
 
 func TestClient_InactiveMonitor(t *testing.T) {
 	inactivityDetected := false
+	defer func() {
+		runtime.GC()
+	}()
 
 	ld, err := coapNet.NewTCPListener("tcp", "")
 	require.NoError(t, err)

--- a/tcp/options.go
+++ b/tcp/options.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/plgd-dev/go-coap/v2/net/blockwise"
 	"github.com/plgd-dev/go-coap/v2/net/keepalive"
+	"github.com/plgd-dev/go-coap/v2/net/monitor/inactivity"
 )
 
 // HandlerFuncOpt handler function option.
@@ -118,6 +119,26 @@ func (o KeepAliveOpt) applyDial(opts *dialOptions) {
 // WithKeepAlive monitoring's client connection's. nil means disable keepalive.
 func WithKeepAlive(keepalive *keepalive.KeepAlive) KeepAliveOpt {
 	return KeepAliveOpt{keepalive: keepalive}
+}
+
+// InactivityMonitorOpt notifies when a connection was inactive for a given duration.
+type InactivityMonitorOpt struct {
+	duration   time.Duration
+	onInactive inactivity.OnInactiveFunc
+}
+
+func (o InactivityMonitorOpt) apply(opts *serverOptions) {
+	opts.createInactivityMonitor = func() inactivity.Monitor {
+		return inactivity.NewInactivityMonitor(o.duration, o.onInactive)
+	}
+}
+
+// WithInactivityMonitor set deadline's for read operations over client connection.
+func WithInactivityMonitor(duration time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
+	return InactivityMonitorOpt{
+		duration:   duration,
+		onInactive: onInactive,
+	}
 }
 
 // NetOpt network option.

--- a/tcp/options.go
+++ b/tcp/options.go
@@ -133,6 +133,12 @@ func (o InactivityMonitorOpt) apply(opts *serverOptions) {
 	}
 }
 
+func (o InactivityMonitorOpt) applyDial(opts *dialOptions) {
+	opts.createInactivityMonitor = func() inactivity.Monitor {
+		return inactivity.NewInactivityMonitor(o.duration, o.onInactive)
+	}
+}
+
 // WithInactivityMonitor set deadline's for read operations over client connection.
 func WithInactivityMonitor(duration time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
 	return InactivityMonitorOpt{

--- a/tcp/server_test.go
+++ b/tcp/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/plgd-dev/go-coap/v2/message"
 	"github.com/plgd-dev/go-coap/v2/message/codes"
 	coapNet "github.com/plgd-dev/go-coap/v2/net"
+	"github.com/plgd-dev/go-coap/v2/net/monitor/inactivity"
 	"github.com/plgd-dev/go-coap/v2/tcp"
 	"github.com/plgd-dev/go-coap/v2/tcp/message/pool"
 	"github.com/stretchr/testify/require"
@@ -145,4 +146,67 @@ func TestServer_SetContextValueWithPKI(t *testing.T) {
 
 	_, err = cc.Get(ctx, "/")
 	require.NoError(t, err)
+}
+
+func TestServer_InactiveMonitor(t *testing.T) {
+	inactivityDetected := false
+
+	ld, err := coapNet.NewTCPListener("tcp", "")
+	require.NoError(t, err)
+	defer ld.Close()
+
+	var checkCloseWg sync.WaitGroup
+	defer checkCloseWg.Wait()
+	sd := tcp.NewServer(
+		tcp.WithOnNewClientConn(func(cc *tcp.ClientConn, tlscon *tls.Conn) {
+			checkCloseWg.Add(1)
+			cc.AddOnClose(func() {
+				checkCloseWg.Done()
+			})
+		}),
+		tcp.WithKeepAlive(nil),
+		tcp.WithInactivityMonitor(100*time.Millisecond, func(cc inactivity.ClientConn) {
+			require.False(t, inactivityDetected)
+			inactivityDetected = true
+			cc.Close()
+		}),
+	)
+
+	var serverWg sync.WaitGroup
+	defer func() {
+		sd.Stop()
+		serverWg.Wait()
+	}()
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		err := sd.Serve(ld)
+		require.NoError(t, err)
+	}()
+
+	cc, err := tcp.Dial(
+		ld.Addr().String(),
+		tcp.WithKeepAlive(nil),
+	)
+	require.NoError(t, err)
+	checkCloseWg.Add(1)
+	cc.AddOnClose(func() {
+		checkCloseWg.Done()
+	})
+
+	// send ping to create serverside connection
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = cc.Ping(ctx)
+	require.NoError(t, err)
+
+	err = cc.Ping(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond * 300)
+
+	cc.Close()
+
+	checkCloseWg.Wait()
+	require.True(t, inactivityDetected)
 }

--- a/udp/client.go
+++ b/udp/client.go
@@ -165,6 +165,7 @@ func Client(conn *net.UDPConn, opts ...DialOption) *client.ClientConn {
 		cfg.goPool,
 		cfg.errors,
 		cfg.getMID,
+		nil,
 	)
 
 	go func() {

--- a/udp/client.go
+++ b/udp/client.go
@@ -165,8 +165,6 @@ func Client(conn *net.UDPConn, opts ...DialOption) *client.ClientConn {
 		cfg.goPool,
 		cfg.errors,
 		cfg.getMID,
-		// The client does not support activity monitoring yet
-		nil,
 	)
 
 	go func() {

--- a/udp/client.go
+++ b/udp/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/plgd-dev/go-coap/v2/message"
 	"github.com/plgd-dev/go-coap/v2/net/blockwise"
 	"github.com/plgd-dev/go-coap/v2/net/keepalive"
+	"github.com/plgd-dev/go-coap/v2/net/monitor/inactivity"
 	kitSync "github.com/plgd-dev/kit/sync"
 
 	"github.com/plgd-dev/go-coap/v2/message/codes"
@@ -47,6 +48,9 @@ var defaultDialOptions = dialOptions{
 	transmissionAcknowledgeTimeout: time.Second * 2,
 	transmissionMaxRetransmit:      4,
 	getMID:                         udpMessage.GetMID,
+	createInactivityMonitor: func() inactivity.Monitor {
+		return inactivity.NewNilMonitor()
+	},
 }
 
 type dialOptions struct {
@@ -67,6 +71,7 @@ type dialOptions struct {
 	transmissionMaxRetransmit      int
 	getMID                         GetMIDFunc
 	closeSocket                    bool
+	createInactivityMonitor        func() inactivity.Monitor
 }
 
 // A DialOption sets options such as credentials, keepalive parameters, etc.
@@ -129,6 +134,12 @@ func Client(conn *net.UDPConn, opts ...DialOption) *client.ClientConn {
 	if cfg.errors == nil {
 		cfg.errors = func(error) {}
 	}
+	if cfg.createInactivityMonitor == nil {
+		cfg.createInactivityMonitor = func() inactivity.Monitor {
+			return inactivity.NewNilMonitor()
+		}
+	}
+
 	errors := cfg.errors
 	cfg.errors = func(err error) {
 		errors(fmt.Errorf("udp: %v: %w", conn.RemoteAddr(), err))
@@ -149,15 +160,19 @@ func Client(conn *net.UDPConn, opts ...DialOption) *client.ClientConn {
 	}
 
 	observationTokenHandler := client.NewHandlerContainer()
-
-	l := coapNet.NewUDPConn(cfg.net, conn, coapNet.WithHeartBeat(cfg.heartBeat), coapNet.WithErrors(cfg.errors))
+	monitor := cfg.createInactivityMonitor()
+	var cc *client.ClientConn
+	l := coapNet.NewUDPConn(cfg.net, conn, coapNet.WithHeartBeat(cfg.heartBeat), coapNet.WithErrors(cfg.errors), coapNet.WithOnReadTimeout(func() error {
+		monitor.CheckInactivity(cc)
+		return nil
+	}))
 	session := NewSession(cfg.ctx,
 		l,
 		addr,
 		cfg.maxMessageSize,
 		cfg.closeSocket,
 	)
-	cc := client.NewClientConn(session,
+	cc = client.NewClientConn(session,
 		observationTokenHandler, observatioRequests, cfg.transmissionNStart, cfg.transmissionAcknowledgeTimeout, cfg.transmissionMaxRetransmit,
 		client.NewObservationHandler(observationTokenHandler, cfg.handler),
 		cfg.blockwiseSZX,
@@ -165,7 +180,7 @@ func Client(conn *net.UDPConn, opts ...DialOption) *client.ClientConn {
 		cfg.goPool,
 		cfg.errors,
 		cfg.getMID,
-		nil,
+		monitor,
 	)
 
 	go func() {

--- a/udp/client_test.go
+++ b/udp/client_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/plgd-dev/go-coap/v2/mux"
+	"github.com/plgd-dev/go-coap/v2/net/monitor/inactivity"
 
 	"github.com/plgd-dev/go-coap/v2/message"
 	"github.com/plgd-dev/go-coap/v2/message/codes"
@@ -610,4 +611,60 @@ func TestClientConn_Ping(t *testing.T) {
 	defer cancel()
 	err = cc.Ping(ctx)
 	require.NoError(t, err)
+}
+
+func TestClient_InactiveMonitor(t *testing.T) {
+	inactivityDetected := false
+
+	ld, err := coapNet.NewListenUDP("udp4", "")
+	require.NoError(t, err)
+	defer ld.Close()
+
+	var checkCloseWg sync.WaitGroup
+	defer checkCloseWg.Wait()
+	sd := NewServer(
+		WithKeepAlive(nil),
+	)
+
+	var serverWg sync.WaitGroup
+	defer func() {
+		sd.Stop()
+		serverWg.Wait()
+	}()
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		err := sd.Serve(ld)
+		require.NoError(t, err)
+	}()
+
+	cc, err := Dial(
+		ld.LocalAddr().String(),
+		WithKeepAlive(nil),
+		WithInactivityMonitor(100*time.Millisecond, func(cc inactivity.ClientConn) {
+			require.False(t, inactivityDetected)
+			inactivityDetected = true
+			cc.Close()
+		}),
+	)
+	require.NoError(t, err)
+	checkCloseWg.Add(1)
+	cc.AddOnClose(func() {
+		checkCloseWg.Done()
+	})
+
+	// send ping to create serverside connection
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err = cc.Ping(ctx)
+	require.NoError(t, err)
+
+	err = cc.Ping(ctx)
+	require.NoError(t, err)
+
+	// wait for fire inactivity
+	time.Sleep(time.Second * 2)
+
+	checkCloseWg.Wait()
+	require.True(t, inactivityDetected)
 }

--- a/udp/client_test.go
+++ b/udp/client_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -615,6 +616,9 @@ func TestClientConn_Ping(t *testing.T) {
 
 func TestClient_InactiveMonitor(t *testing.T) {
 	inactivityDetected := false
+	defer func() {
+		runtime.GC()
+	}()
 
 	ld, err := coapNet.NewListenUDP("udp4", "")
 	require.NoError(t, err)

--- a/udp/options.go
+++ b/udp/options.go
@@ -128,14 +128,14 @@ type InactivityMonitorOpt struct {
 
 func (o InactivityMonitorOpt) apply(opts *serverOptions) {
 	opts.createInactivityMonitor = func() inactivity.Monitor {
-		return inactivity.NewInactivityMonitor(o.interval, o.onInactive)
+		return inactivity.NewInactivityMonitor(o.duration, o.onInactive)
 	}
 }
 
 // WithInactivityMonitor set deadline's for read operations over client connection.
 func WithInactivityMonitor(duration time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
 	return InactivityMonitorOpt{
-		interval:   interval,
+		duration:   duration,
 		onInactive: onInactive,
 	}
 }

--- a/udp/options.go
+++ b/udp/options.go
@@ -122,17 +122,21 @@ func WithKeepAlive(keepalive *keepalive.KeepAlive) KeepAliveOpt {
 
 // InactivityMonitorOpt notifies when a connection was inactive for a given duration.
 type InactivityMonitorOpt struct {
-	inactivityMonitor inactivity.Monitor
+	duration   time.Duration
+	onInactive inactivity.OnInactiveFunc
 }
 
 func (o InactivityMonitorOpt) apply(opts *serverOptions) {
-	opts.inactivityMonitor = o.inactivityMonitor
+	opts.createInactivityMonitor = func() inactivity.Monitor {
+		return inactivity.NewInactivityMonitor(o.interval, o.onInactive)
+	}
 }
 
-// WithInactivityMonitor set deadline's for read/write operations over client connection.
-func WithInactivityMonitor(interval time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
+// WithInactivityMonitor set deadline's for read operations over client connection.
+func WithInactivityMonitor(duration time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
 	return InactivityMonitorOpt{
-		inactivityMonitor: inactivity.NewInactivityMonitor(interval, onInactive),
+		interval:   interval,
+		onInactive: onInactive,
 	}
 }
 

--- a/udp/options.go
+++ b/udp/options.go
@@ -132,6 +132,12 @@ func (o InactivityMonitorOpt) apply(opts *serverOptions) {
 	}
 }
 
+func (o InactivityMonitorOpt) applyDial(opts *dialOptions) {
+	opts.createInactivityMonitor = func() inactivity.Monitor {
+		return inactivity.NewInactivityMonitor(o.duration, o.onInactive)
+	}
+}
+
 // WithInactivityMonitor set deadline's for read operations over client connection.
 func WithInactivityMonitor(duration time.Duration, onInactive inactivity.OnInactiveFunc) InactivityMonitorOpt {
 	return InactivityMonitorOpt{

--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -230,6 +230,9 @@ func TestServer_InactiveMonitor(t *testing.T) {
 	err = cc.Ping(ctx)
 	require.NoError(t, err)
 
+	// wait for fire inactivity
+	time.Sleep(time.Second * 2)
+
 	cc.Close()
 
 	checkCloseWg.Wait()


### PR DESCRIPTION
In old implementation it spawn go-routine per connection for check if the connection is inactive. Now it is handled directly by connection for DTLS/TCP. For udp it creates one goroutine which goes through all udp connections and check if they are inactive. 

added support inactivity monitor for clients