### PR TITLE
Fix an issue which prevents blockwise xfer working with observe

### DIFF
--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -736,9 +736,13 @@ func (b *BlockWise) processReceivedMessage(w ResponseWriter, r Message, maxSzx S
 	cachedReceivedMessageETAG, errCachedReceivedMessageETAG := cachedReceivedMessage.GetOptionBytes(message.ETag)
 	switch {
 	case errETAG == nil && errCachedReceivedMessageETAG != nil:
-		return fmt.Errorf("received message doesn't contains ETAG but cached received message contains it(%v)", cachedReceivedMessageETAG)
+		if len(cachedReceivedMessageETAG) > 0 { // make sure there is an etag there
+			return fmt.Errorf("received message doesn't contains ETAG but cached received message contains it(%v)", cachedReceivedMessageETAG)
+		}
 	case errETAG != nil && errCachedReceivedMessageETAG == nil:
-		return fmt.Errorf("received message contains ETAG(%v) but cached received message doesn't", rETAG)
+		if len(rETAG) > 0 { // make sure there is an etag there
+			return fmt.Errorf("received message contains ETAG(%v) but cached received message doesn't", rETAG)
+		}
 	case !bytes.Equal(rETAG, cachedReceivedMessageETAG):
 		return fmt.Errorf("received message ETAG(%v) is not equal to cached received message ETAG(%v)", rETAG, cachedReceivedMessageETAG)
 	}


### PR DESCRIPTION
If you observe a resource and the state change is too big for a single
packet, it will be sent blockwise. However, only the first block is
sent with the observe token, it is expected that clients will request
subsequent blocks by issuing a new request. Returning a response to
this new request would fail on the client due to ETags not matching,
despite no ETags being used. The failure error was:

  received message doesn't contains ETAG but cached received message contains it([])

This patch ensures that the received message actually contains an
ETag, which fixes this issue.