### PR TITLE
[Feat] Add support for route params

### DIFF
--- a/message/options.go
+++ b/message/options.go
@@ -50,15 +50,14 @@ func (options Options) path(buf []byte) (int, error) {
 		needed += len(options[i].Value)
 		needed++
 	}
-	needed--
+
 	if len(buf) < needed {
 		return needed, ErrTooSmall
 	}
 	for i := firstIdx; i < lastIdx; i++ {
-		if i != firstIdx {
-			buf[0] = '/'
-			buf = buf[1:]
-		}
+		buf[0] = '/'
+		buf = buf[1:]
+
 		copy(buf, options[i].Value)
 		buf = buf[len(options[i].Value):]
 	}

--- a/mux/message.go
+++ b/mux/message.go
@@ -2,6 +2,12 @@ package mux
 
 import "github.com/plgd-dev/go-coap/v2/message"
 
+// RouteParams contains all the information related to a route
+type RouteParams struct {
+	Path string
+	Vars map[string]string
+}
+
 // Message contains message with sequence number.
 type Message struct {
 	*message.Message
@@ -12,4 +18,5 @@ type Message struct {
 	// Long running handlers can be handled in a go routine and send the response via w.Client().
 	// The ACK is sent as soon as the handler returns.
 	IsConfirmable bool
+	RouteParams   *RouteParams
 }

--- a/mux/regexp.go
+++ b/mux/regexp.go
@@ -1,0 +1,143 @@
+package mux
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func newRouteRegexp(path string) (*routeRegexp, error) {
+	// Check if it is well-formed.
+	idxs, errBraces := braceIndices(path)
+	if errBraces != nil {
+		return nil, errBraces
+	}
+	// Backup the original.
+	template := path
+	// Now let's parse it.
+	defaultPattern := "[^/]+"
+	varsN := make([]string, len(idxs)/2)
+	varsR := make([]*regexp.Regexp, len(idxs)/2)
+	pattern := bytes.NewBufferString("")
+	pattern.WriteByte('^')
+	reverse := bytes.NewBufferString("")
+	var end int
+	var err error
+	for i := 0; i < len(idxs); i += 2 {
+		// Set all values we are interested in.
+		raw := path[end:idxs[i]]
+		end = idxs[i+1]
+		parts := strings.SplitN(path[idxs[i]+1:end-1], ":", 2)
+		name := parts[0]
+		patt := defaultPattern
+		if len(parts) == 2 {
+			patt = parts[1]
+		}
+		// Name or pattern can't be empty.
+		if name == "" || patt == "" {
+			return nil, fmt.Errorf("mux: missing name or pattern in %q",
+				path[idxs[i]:end])
+		}
+		// Build the regexp pattern.
+		fmt.Fprintf(pattern, "%s(?P<%s>%s)", regexp.QuoteMeta(raw), varGroupName(i/2), patt)
+
+		// Build the reverse template.
+		fmt.Fprintf(reverse, "%s%%s", raw)
+
+		// Append variable name and compiled pattern.
+		varsN[i/2] = name
+		varsR[i/2], err = regexp.Compile(fmt.Sprintf("^%s$", patt))
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Add the remaining.
+	raw := path[end:]
+	pattern.WriteString(regexp.QuoteMeta(raw))
+
+	pattern.WriteByte('$')
+
+	// Compile full regexp.
+	reg, errCompile := regexp.Compile(pattern.String())
+	if errCompile != nil {
+		return nil, errCompile
+	}
+
+	// Check for capturing groups which used to work in older versions
+	if reg.NumSubexp() != len(idxs)/2 {
+		panic(fmt.Sprintf("route %s contains capture groups in its regexp. ", template) +
+			"Only non-capturing groups are accepted: e.g. (?:pattern) instead of (pattern)")
+	}
+
+	// Done!
+	return &routeRegexp{
+		template: template,
+		regexp:   reg,
+		reverse:  reverse.String(),
+		varsN:    varsN,
+		varsR:    varsR,
+	}, nil
+}
+
+// routeRegexp stores a regexp to match a host or path and information to
+// collect and validate route variables.
+type routeRegexp struct {
+	// The unmodified template.
+	template string
+
+	// Expanded regexp.
+	regexp *regexp.Regexp
+	// Reverse template.
+	reverse string
+	// Variable names.
+	varsN []string
+	// Variable regexps (validators).
+	varsR []*regexp.Regexp
+	// Wildcard host-port (no strict port match in hostname)
+	wildcardHostPort bool
+}
+
+// varGroupName builds a capturing group name for the indexed variable.
+func varGroupName(idx int) string {
+	return "v" + strconv.Itoa(idx)
+}
+
+// braceIndices returns the first level curly brace indices from a string.
+// It returns an error in case of unbalanced braces.
+func braceIndices(s string) ([]int, error) {
+	var level, idx int
+	var idxs []int
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			if level++; level == 1 {
+				idx = i
+			}
+		case '}':
+			if level--; level == 0 {
+				idxs = append(idxs, idx, i+1)
+			} else if level < 0 {
+				return nil, fmt.Errorf("mux: unbalanced braces in %q", s)
+			}
+		}
+	}
+	if level != 0 {
+		return nil, fmt.Errorf("mux: unbalanced braces in %q", s)
+	}
+	return idxs, nil
+}
+
+func (route *routeRegexp) extractRouteParams(path string, routeParams *RouteParams) {
+	matches := route.regexp.FindStringSubmatchIndex(path)
+	if len(matches) > 0 {
+		extractVars(path, matches, route.varsN, routeParams.Vars)
+	}
+}
+
+func extractVars(input string, matches []int, names []string, output map[string]string) {
+	for i, name := range names {
+		output[name] = input[matches[2*i+2]:matches[2*i+3]]
+	}
+}

--- a/mux/router.go
+++ b/mux/router.go
@@ -35,21 +35,29 @@ func (f HandlerFunc) ServeCOAP(w ResponseWriter, r *Message) {
 // with same name.
 // Router is also safe for concurrent access from multiple goroutines.
 type Router struct {
-	z              map[string]muxEntry
+	z              map[string]Route
 	m              *sync.RWMutex
 	defaultHandler Handler
 	middlewares    []MiddlewareFunc
 }
 
-type muxEntry struct {
-	h       Handler
-	pattern string
+type Route struct {
+	h            Handler
+	pattern      string
+	regexMatcher *routeRegexp
+}
+
+func (route *Route) GetRouteRegexp() (string, error) {
+	if route.regexMatcher.regexp == nil {
+		return "", errors.New("mux: route does not have a regexp")
+	}
+	return route.regexMatcher.regexp.String(), nil
 }
 
 // NewRouter allocates and returns a new Router.
 func NewRouter() *Router {
 	return &Router{
-		z:           make(map[string]muxEntry),
+		z:           make(map[string]Route),
 		m:           new(sync.RWMutex),
 		middlewares: make([]MiddlewareFunc, 0, 2),
 		defaultHandler: HandlerFunc(func(w ResponseWriter, r *Message) {
@@ -59,39 +67,36 @@ func NewRouter() *Router {
 }
 
 // Does path match pattern?
-func pathMatch(pattern, path string) bool {
-	switch pattern {
-	case "", "/":
-		switch path {
-		case "", "/":
-			return true
-		}
-		return false
-	default:
-		n := len(pattern)
-		if pattern[n-1] != '/' {
-			return pattern == path
-		}
-		return len(path) >= n && path[0:n] == pattern
-	}
+func pathMatch(pattern Route, path string) bool {
+	return pattern.regexMatcher.regexp.MatchString(path)
 }
 
 // Find a handler on a handler map given a path string
 // Most-specific (longest) pattern wins
-func (r *Router) match(path string) (h Handler, pattern string) {
+func (r *Router) Match(path string, routeParams *RouteParams) (matchedRoute *Route, matchedPattern string) {
 	r.m.RLock()
 	defer r.m.RUnlock()
 	var n = 0
-	for k, v := range r.z {
-		if !pathMatch(k, path) {
+	for pattern, route := range r.z {
+		if !pathMatch(route, path) {
 			continue
 		}
-		if h == nil || len(k) > n {
-			n = len(k)
-			h = v.h
-			pattern = v.pattern
+		if matchedRoute == nil || len(pattern) > n {
+			n = len(pattern)
+			matchedRoute = &route
+			matchedPattern = pattern
 		}
 	}
+
+	routeParams.Path = path
+	if routeParams.Vars == nil {
+		routeParams.Vars = make(map[string]string)
+	}
+
+	if matchedRoute != nil {
+		matchedRoute.regexMatcher.extractRouteParams(path, routeParams)
+	}
+
 	return
 }
 
@@ -100,18 +105,19 @@ func (r *Router) Handle(pattern string, handler Handler) error {
 	switch pattern {
 	case "", "/":
 		pattern = "/"
-	default:
-		if pattern[0] == '/' {
-			pattern = pattern[1:]
-		}
 	}
 
 	if handler == nil {
 		return errors.New("nil handler")
 	}
 
+	routeRegex, err := newRouteRegexp(pattern)
+	if err != nil {
+		return err
+	}
+
 	r.m.Lock()
-	r.z[pattern] = muxEntry{h: handler, pattern: pattern}
+	r.z[pattern] = Route{h: handler, pattern: pattern, regexMatcher: routeRegex}
 	r.m.Unlock()
 	return nil
 }
@@ -148,6 +154,18 @@ func (r *Router) HandleRemove(pattern string) error {
 	return errors.New("pattern is not registered in")
 }
 
+// GetRoute obtains route from the pattern it has been assigned
+func (r *Router) GetRoute(pattern string) *Route {
+	if route, ok := r.z[pattern]; ok {
+		return &route
+	}
+	return nil
+}
+
+func (r *Router) GetRoutes() map[string]Route {
+	return r.z
+}
+
 // ServeCOAP dispatches the request to the handler whose
 // pattern most closely matches the request message. If DefaultServeMux
 // is used the correct thing for DS queries is done: a possible parent
@@ -159,13 +177,17 @@ func (r *Router) ServeCOAP(w ResponseWriter, req *Message) {
 		r.defaultHandler.ServeCOAP(w, req)
 		return
 	}
-	h, _ := r.match(path)
-	if h == nil {
+	var h Handler
+	matchedMuxEntry, _ := r.Match(path, req.RouteParams)
+	if matchedMuxEntry == nil {
 		h = r.defaultHandler
+	} else {
+		h = matchedMuxEntry.h
 	}
 	if h == nil {
 		return
 	}
+
 	for i := len(r.middlewares) - 1; i >= 0; i-- {
 		h = r.middlewares[i].Middleware(h)
 	}

--- a/mux/router_test.go
+++ b/mux/router_test.go
@@ -1,0 +1,133 @@
+package mux_test
+
+import (
+	"testing"
+
+	"github.com/plgd-dev/go-coap/v2/mux"
+)
+
+type routeTest struct {
+	title        string // title of the test
+	path         string
+	pathTemplate string
+	vars         map[string]string // the expected vars of the match
+	shouldMatch  bool              // whether the request is expected to match the route at all
+	pathRegexp   string
+}
+
+func TestMux(t *testing.T) {
+	r := mux.NewRouter()
+	tests := []routeTest{
+		{
+			title:        "Path route match",
+			path:         "/111/222/333",
+			pathTemplate: "/111/222/333",
+			shouldMatch:  true,
+			vars:         map[string]string{},
+		},
+		{
+			title:        "Path route with pattern, match",
+			path:         "/111/222/333",
+			pathTemplate: "/111/{v1:[0-9]{3}}/333",
+			shouldMatch:  true,
+			vars:         map[string]string{"v1": "222"},
+		},
+		{
+			title:        "Path route with pattern, no match",
+			path:         "/111/aaa/333",
+			pathTemplate: "/111/{v1:[0-9]{3}}/333",
+			shouldMatch:  false,
+			vars:         map[string]string{"v1": "222"},
+			pathRegexp:   `^/111/(?P<v0>[0-9]{3})/333$`,
+		},
+		{
+			title:        "Path route with multiple patterns, match",
+			vars:         map[string]string{"test": "111", "v2": "222", "v3": "333"},
+			path:         "/111/222/333",
+			pathTemplate: `/{test:[0-9]{3}}/{v2:[0-9]{3}}/{v3:[0-9]{3}}`,
+			shouldMatch:  true,
+		},
+		{
+			title:        "Path route with multiple hyphenated names and patterns with pipe, match",
+			vars:         map[string]string{"product-category": "a", "product-name": "product_name", "product-id": "1"},
+			path:         "/a/product_name/1",
+			pathTemplate: `/{product-category:a|(?:b/c)}/{product-name}/{product-id:[0-9]+}`,
+			pathRegexp:   `^/(?P<v0>a|(?:b/c))/(?P<v1>[^/]+)/(?P<v2>[0-9]+)$`,
+			shouldMatch:  true,
+		},
+		{
+			title:        "Path route with empty match right after other match",
+			vars:         map[string]string{"v1": "111", "v2": "", "v3": "222"},
+			path:         "/111/222",
+			pathTemplate: `/{v1:[0-9]*}{v2:[a-z]*}/{v3:[0-9]*}`,
+			pathRegexp:   `^/(?P<v0>[0-9]*)(?P<v1>[a-z]*)/(?P<v2>[0-9]*)$`,
+			shouldMatch:  true,
+		},
+		{
+			title:        "Path route with single pattern with pipe, match",
+			vars:         map[string]string{"category": "a"},
+			path:         "/a",
+			pathTemplate: `/{category:a|b/c}`,
+			shouldMatch:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			r.HandleFunc(test.pathTemplate, func(w mux.ResponseWriter, r *mux.Message) {})
+			testRegexp(t, r, test)
+			testRoute(t, r, test)
+			r.HandleRemove(test.pathTemplate)
+		})
+	}
+}
+
+func testRegexp(t *testing.T, router *mux.Router, test routeTest) {
+
+	route := router.GetRoute(test.pathTemplate)
+
+	if route == nil {
+		t.Errorf("(%v) GetRoute: expected to find route %v", test.title, test.pathTemplate)
+		return
+	}
+	routePathRegexp, regexpErr := route.GetRouteRegexp()
+	if test.pathRegexp != "" && regexpErr == nil && routePathRegexp != test.pathRegexp {
+		t.Errorf("(%v) PathRegexp not equal: expected %v, got %v", test.title, test.pathRegexp, routePathRegexp)
+	}
+}
+
+func testRoute(t *testing.T, router *mux.Router, test routeTest) {
+	routeParams := new(mux.RouteParams)
+	vars := test.vars
+	route, _ := router.Match(test.path, routeParams)
+	matched := route != nil
+	if matched != test.shouldMatch {
+		msg := "Should match"
+		if !test.shouldMatch {
+			msg = "Should not match"
+		}
+		t.Errorf("(%v) %v:\nPath: %#v\nPathTemplate: %#v\nVars: %v\n", test.title, msg, test.path, test.pathTemplate, test.vars)
+	}
+	if test.shouldMatch {
+		if vars != nil && !stringMapEqual(vars, routeParams.Vars) {
+			t.Errorf("(%v) Vars not equal: expected %v, got %v", test.title, vars, routeParams.Vars)
+			return
+		}
+	}
+
+}
+
+// stringMapEqual checks the equality of two string maps
+func stringMapEqual(m1, m2 map[string]string) bool {
+	nil1 := m1 == nil
+	nil2 := m2 == nil
+	if nil1 != nil2 || len(m1) != len(m2) {
+		return false
+	}
+	for k, v := range m1 {
+		if v != m2[k] {
+			return false
+		}
+	}
+	return true
+}

--- a/mux/router_test.go
+++ b/mux/router_test.go
@@ -26,6 +26,13 @@ func TestMux(t *testing.T) {
 			vars:         map[string]string{},
 		},
 		{
+			title:        "Path route with pattern no constraints, match",
+			path:         "/111/222/333",
+			pathTemplate: "/111/{v1}/333",
+			shouldMatch:  true,
+			vars:         map[string]string{"v1": "222"},
+		},
+		{
 			title:        "Path route with pattern, match",
 			path:         "/111/222/333",
 			pathTemplate: "/111/{v1:[0-9]{3}}/333",

--- a/tcp/optionmux.go
+++ b/tcp/optionmux.go
@@ -22,6 +22,7 @@ func WithMux(m mux.Handler) HandlerFuncOpt {
 		m.ServeCOAP(muxw, &mux.Message{
 			Message:        muxr,
 			SequenceNumber: r.Sequence(),
+			RouteParams:    new(mux.RouteParams),
 		})
 	}
 	return WithHandlerFunc(h)

--- a/udp/client/mux.go
+++ b/udp/client/mux.go
@@ -23,6 +23,7 @@ func HandlerFuncToMux(m mux.Handler) HandlerFunc {
 			Message:        muxr,
 			SequenceNumber: r.Sequence(),
 			IsConfirmable:  r.Type() == udpMessage.Confirmable,
+			RouteParams:    new(mux.RouteParams),
 		})
 	}
 	return h


### PR DESCRIPTION
Added support for parameters in the routes, which are then stored in a RouteParams config object passed to the HandleFunction.

The code is mostly taken and adapted from [gorilla mux](https://github.com/gorilla/mux). I suppose there isn't a problem from taking code from there but please let me know if there is.
 
### Changes

- Routes can now be entered with route parameters such as /example/{id}/{id2} and will match the correct HandleFunction
- Matcher allows for regex expressions: /example/{v1:[0-9]{3}}/hello
- Added tests for the mux to control as many cases as possible
- mux.Message now also contains a RouteParams struct which has the path entered and the Variables stored as a string map
- Routes should always have a / at the start