### PR TITLE
observation: handle state when the resource observation is not supported

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,11 @@
 {
+    "go.testFlags": [
+        "-race",
+        "-v",
+        "-cover",
+        "-p",
+        "1",
+    ],
     "go.testEnvVars": {
      //   "GOFLAGS":"-mod=vendor",
     },

--- a/mux/client.go
+++ b/mux/client.go
@@ -10,6 +10,7 @@ import (
 
 type Observation = interface {
 	Cancel(ctx context.Context) error
+	Canceled() bool
 }
 
 type Client interface {

--- a/tcp/clientobserve_test.go
+++ b/tcp/clientobserve_test.go
@@ -3,7 +3,6 @@ package tcp
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -26,16 +25,14 @@ func TestClientConn_Observe(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		/*
-			{
-				name: "10bytes",
-				args: args{
-					path:      "/tmp",
-					numEvents: 1,
-					payload:   make([]byte, 10),
-				},
+		{
+			name: "10bytes",
+			args: args{
+				path:      "/tmp",
+				numEvents: 1,
+				payload:   make([]byte, 10),
 			},
-		*/
+		},
 		{
 			name: "5000bytes",
 			args: args{
@@ -133,6 +130,116 @@ func TestClientConn_Observe(t *testing.T) {
 			require.NoError(t, err)
 			<-obs.done
 			err = got.Cancel(ctx)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestClientConnObserveNotSupported(t *testing.T) {
+	type args struct {
+		path    string
+		payload []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "10bytes",
+			args: args{
+				path:    "/tmp",
+				payload: make([]byte, 10),
+			},
+		},
+		{
+			name: "5000bytes",
+			args: args{
+				path:    "/tmp",
+				payload: make([]byte, 5000),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := coapNet.NewTCPListener("tcp", "")
+			require.NoError(t, err)
+			defer l.Close()
+			var wg sync.WaitGroup
+			defer wg.Wait()
+
+			s := NewServer(WithHandlerFunc(func(w *ResponseWriter, r *pool.Message) {
+				switch r.Code() {
+				case codes.PUT, codes.POST, codes.DELETE:
+					w.SetResponse(codes.NotFound, message.TextPlain, nil)
+				case codes.GET:
+				default:
+					return
+				}
+				obs, err := r.Observe()
+				if err != nil {
+					err := w.SetResponse(codes.Content, message.TextPlain, bytes.NewReader(tt.args.payload))
+					require.NoError(t, err)
+					return
+				}
+				require.NoError(t, err)
+				require.NotNil(t, w.ClientConn())
+				token := r.Token()
+				switch obs {
+				case 0:
+					cc := w.ClientConn()
+					tmpPay := make([]byte, len(tt.args.payload))
+					copy(tmpPay, tt.args.payload)
+					p := bytes.NewReader(tt.args.payload)
+					etag, err := message.GetETag(p)
+					require.NoError(t, err)
+					req := pool.AcquireMessage(cc.Context())
+					defer pool.ReleaseMessage(req)
+					req.SetCode(codes.Content)
+					req.SetContentFormat(message.TextPlain)
+					req.SetBody(p)
+					req.SetETag(etag)
+					req.SetToken(token)
+					err = cc.WriteMessage(req)
+					require.NoError(t, err)
+				case 1:
+					err := w.SetResponse(codes.Content, message.TextPlain, bytes.NewReader([]byte("close")))
+					require.NoError(t, err)
+				default:
+					err := w.SetResponse(codes.BadRequest, message.TextPlain, nil)
+					require.NoError(t, err)
+				}
+			}))
+			defer s.Stop()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := s.Serve(l)
+				require.NoError(t, err)
+			}()
+
+			cc, err := Dial(l.Addr().String())
+			require.NoError(t, err)
+			defer cc.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*3600)
+			defer cancel()
+			obs := &observer{
+				t:                        t,
+				done:                     make(chan bool, 1),
+				numEvents:                1,
+				observeOptionNotRequired: true,
+			}
+			got, err := cc.Observe(ctx, tt.args.path, obs.observe)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			<-obs.done
+			err = got.Cancel(ctx)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -160,8 +267,9 @@ type observer struct {
 	t    require.TestingT
 	msgs []*pool.Message
 	sync.Mutex
-	done      chan bool
-	numEvents int
+	done                     chan bool
+	numEvents                int
+	observeOptionNotRequired bool
 }
 
 func (o *observer) observe(req *pool.Message) {
@@ -169,9 +277,12 @@ func (o *observer) observe(req *pool.Message) {
 	o.Lock()
 	defer o.Unlock()
 	o.msgs = append(o.msgs, req)
+	if o.observeOptionNotRequired {
+		o.done <- true
+		return
+	}
 	obs, err := req.Observe()
 	require.NoError(o.t, err)
-	fmt.Printf("OBS %v\n", obs)
 	if obs > uint32(o.numEvents) {
 		select {
 		case o.done <- true:

--- a/udp/client/clientobserve.go
+++ b/udp/client/clientobserve.go
@@ -29,13 +29,18 @@ func NewObservationHandler(obsertionTokenHandler *HandlerContainer, next Handler
 	}
 }
 
+type respObservationMessage struct {
+	code         codes.Code
+	notSupported bool
+}
+
 //Observation represents subscription to resource on the server
 type Observation struct {
-	token        message.Token
-	path         string
-	cc           *ClientConn
-	observeFunc  func(req *pool.Message)
-	respCodeChan chan codes.Code
+	token               message.Token
+	path                string
+	cc                  *ClientConn
+	observeFunc         func(req *pool.Message)
+	respObservationChan chan respObservationMessage
 
 	obsSequence uint32
 	etag        []byte
@@ -45,34 +50,44 @@ type Observation struct {
 	waitForReponse uint32
 }
 
-func newObservation(token message.Token, path string, cc *ClientConn, observeFunc func(req *pool.Message), respCodeChan chan codes.Code) *Observation {
+func newObservation(token message.Token, path string, cc *ClientConn, observeFunc func(req *pool.Message), respObservationChan chan respObservationMessage) *Observation {
 	return &Observation{
-		token:          token,
-		path:           path,
-		obsSequence:    0,
-		cc:             cc,
-		waitForReponse: 1,
-		respCodeChan:   respCodeChan,
-		observeFunc:    observeFunc,
+		token:               token,
+		path:                path,
+		obsSequence:         0,
+		cc:                  cc,
+		waitForReponse:      1,
+		respObservationChan: respObservationChan,
+		observeFunc:         observeFunc,
 	}
 }
 
-func (o *Observation) cleanUp() {
+func (o *Observation) Canceled() bool {
+	_, ok := o.cc.observationRequests.Load(o.token.String())
+	return !ok
+}
+
+func (o *Observation) cleanUp() bool {
 	o.cc.observationTokenHandler.Pop(o.token)
 	registeredRequest, ok := o.cc.observationRequests.PullOut(o.token.String())
 	if ok {
 		pool.ReleaseMessage(registeredRequest.(*pool.Message))
 	}
+	return ok
 }
 
 func (o *Observation) handler(w *ResponseWriter, r *pool.Message) {
 	code := r.Code()
+	notSupported := !r.HasOption(message.Observe)
 	if atomic.CompareAndSwapUint32(&o.waitForReponse, 1, 0) {
 		select {
-		case o.respCodeChan <- code:
+		case o.respObservationChan <- respObservationMessage{
+			code:         code,
+			notSupported: notSupported,
+		}:
 		default:
 		}
-		o.respCodeChan = nil
+		o.respObservationChan = nil
 	}
 	if o.wantBeNotified(r) {
 		o.observeFunc(r)
@@ -81,7 +96,10 @@ func (o *Observation) handler(w *ResponseWriter, r *pool.Message) {
 
 // Cancel remove observation from server. For recreate observation use Observe.
 func (o *Observation) Cancel(ctx context.Context) error {
-	o.cleanUp()
+	if !o.cleanUp() {
+		// observation was already cleanup
+		return nil
+	}
 	req, err := NewGetRequest(ctx, o.path)
 	if err != nil {
 		return fmt.Errorf("cannot cancel observation request: %w", err)
@@ -119,16 +137,17 @@ func (o *Observation) wantBeNotified(r *pool.Message) bool {
 	return false
 }
 
-// Observe subscribes for every change of resource on path.
-func (cc *ClientConn) Observe(ctx context.Context, path string, observeFunc func(req *pool.Message), opts ...message.Option) (*Observation, error) {
+// Observe subscribes for every change of resource on path. It can return canceled observation and it happens when resource doesn't support observation.
+// This is detected when the first notification doesn't contains observe option.
+func (cc *ClientConn) Observe(ctx context.Context, path string, observeFunc func(msg *pool.Message), opts ...message.Option) (*Observation, error) {
 	req, err := NewGetRequest(ctx, path, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create observe request: %w", err)
 	}
 	token := req.Token()
 	req.SetObserve(0)
-	respCodeChan := make(chan codes.Code, 1)
-	o := newObservation(token, path, cc, observeFunc, respCodeChan)
+	respObservationChan := make(chan respObservationMessage, 1)
+	o := newObservation(token, path, cc, observeFunc, respObservationChan)
 
 	cc.observationRequests.Store(token.String(), req)
 	err = o.cc.observationTokenHandler.Insert(token.String(), o.handler)
@@ -152,10 +171,13 @@ func (cc *ClientConn) Observe(ctx context.Context, path string, observeFunc func
 	case <-cc.Context().Done():
 		err = fmt.Errorf("connection was closed: %w", cc.Context().Err())
 		return nil, err
-	case respCode := <-respCodeChan:
-		if respCode != codes.Content {
-			err = fmt.Errorf("unexpected return code(%v)", respCode)
+	case respObservationMessage := <-respObservationChan:
+		if respObservationMessage.code != codes.Content {
+			err = fmt.Errorf("unexpected return code(%v)", respObservationMessage.code)
 			return nil, err
+		}
+		if respObservationMessage.notSupported {
+			o.cleanUp()
 		}
 		return o, nil
 	}


### PR DESCRIPTION
when the client receives a notification without observing option, it
means that the resource doesn't support the observation.

- added a call to check if the observation is canceled `obs.Canceled`
- automatically clean up observation, so users don't need to call
`obs.Cancel`