### PR TITLE
fix atomic alignment on 32-bit platforms

### DIFF
--- a/tcp/message/pool/message.go
+++ b/tcp/message/pool/message.go
@@ -97,8 +97,10 @@ func (r *Message) Marshal() ([]byte, error) {
 }
 
 type Pool struct {
-	messagePool           sync.Pool
+	// This field needs to be the first in the struct to ensure proper word alignment on 32-bit platforms.
+	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	currentMessagesInPool int64
+	messagePool           sync.Pool
 	maxNumMessages        uint32
 	maxMessageBufferSize  uint16
 }

--- a/udp/message/pool/message.go
+++ b/udp/message/pool/message.go
@@ -155,8 +155,10 @@ func (r *Message) String() string {
 }
 
 type Pool struct {
-	messagePool           sync.Pool
+	// This field needs to be the first in the struct to ensure proper word alignment on 32-bit platforms.
+	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	currentMessagesInPool int64
+	messagePool           sync.Pool
 	maxNumMessages        uint32
 	maxMessageBufferSize  uint16
 }


### PR DESCRIPTION
On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.