### PR TITLE
Add PathTemplate to RouteParams

### DIFF
--- a/mux/message.go
+++ b/mux/message.go
@@ -4,8 +4,9 @@ import "github.com/plgd-dev/go-coap/v2/message"
 
 // RouteParams contains all the information related to a route
 type RouteParams struct {
-	Path string
-	Vars map[string]string
+	Path         string
+	Vars         map[string]string
+	PathTemplate string
 }
 
 // Message contains message with sequence number.

--- a/mux/router.go
+++ b/mux/router.go
@@ -109,6 +109,7 @@ func (r *Router) Match(path string, routeParams *RouteParams) (matchedRoute *Rou
 	if routeParams.Vars == nil {
 		routeParams.Vars = make(map[string]string)
 	}
+	routeParams.PathTemplate = matchedPattern
 	matchedRoute.regexMatcher.extractRouteParams(path, routeParams)
 
 	return

--- a/mux/router_test.go
+++ b/mux/router_test.go
@@ -122,6 +122,11 @@ func testRoute(t *testing.T, router *mux.Router, test routeTest) {
 			t.Errorf("(%v) Vars not equal: expected %v, got %v", test.title, vars, routeParams.Vars)
 			return
 		}
+
+		if routeParams.PathTemplate != test.pathTemplate {
+			t.Errorf("(%v) PathTemplate not equal: expected %v, got %v", test.title, test.pathTemplate, test.pathTemplate)
+			return
+		}
 	}
 
 }


### PR DESCRIPTION
The `PathTemplate` (or route pattern) is quite useful in the middlewares, for example when you want to aggregate metrics by endpoint rather than by path.

Example use in `gorilla/mux`:
```go
// prometheusMiddleware implements mux.MiddlewareFunc.
func prometheusMiddleware(next http.Handler) http.Handler {
  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
    route := mux.CurrentRoute(r)
    path, _ := route.GetPathTemplate()
    timer := prometheus.NewTimer(httpDuration.WithLabelValues(path))
    next.ServeHTTP(w, r)
    timer.ObserveDuration()
  })
}
```
https://www.robustperception.io/prometheus-middleware-for-gorilla-mux