### PR TITLE
examples/observe/server: fix buf usage

### DIFF
--- a/examples/observe/server/main.go
+++ b/examples/observe/server/main.go
@@ -38,6 +38,7 @@ func sendResponse(cc mux.Client, token []byte, subded time.Time, obs int64) erro
 	if err != nil {
 		return fmt.Errorf("cannot set content format to response: %w", err)
 	}
+	buf = buf[n:]
 	if obs >= 0 {
 		opts, n, err = opts.SetObserve(buf, uint32(obs))
 		if err == message.ErrTooSmall {


### PR DESCRIPTION
The observe server example uses the same buffer for both the content of
the Content-Format and the Observe option. This does work int he example
by accident, as the used Content-Format is 0 and, hence, is encoded with
a zero-length option value. If modified like this, the issue becomes
apparent:

```diff
diff --git a/examples/observe/server/main.go b/examples/observe/server/main.go
index 08664a6..6ab6119 100644
--- a/examples/observe/server/main.go
+++ b/examples/observe/server/main.go
@@ -30,10 +30,10 @@ func sendResponse(cc mux.Client, token []byte, subded time.Time, obs int64) erro
     }
     var opts message.Options
     var buf []byte
-    opts, n, err := opts.SetContentFormat(buf, message.TextPlain)
+    opts, n, err := opts.SetContentFormat(buf, message.AppJSON)
     if err == message.ErrTooSmall {
         buf = append(buf, make([]byte, n)...)
-        opts, _, err = opts.SetContentFormat(buf, message.TextPlain)
+        opts, _, err = opts.SetContentFormat(buf, message.AppJSON)
     }
     if err != nil {
         return fmt.Errorf("cannot set content format to response: %w", err)
```

As message.AppJSON is a non-zero value, it will actually write content
to the buffer buf. This buffer is subsequently reused for the Observe
option and the value it holds (the 50 for AppJSON) is overwritten by
the Observe Option content, corrupting the outgoing message. (This can
easily verified with Wireshark, which shows the content format to count
up with the observe number after applying the patch above).

This commit uses different buffers for each option. Note that while this
bug is not triggered with message.TextPlain, application developers will
base their code on this example and are bound to be hitting this bug the
moment the use a different content format.