### PR TITLE
Fix for messages coming from the message pool always ends up as non-confirmable

### DIFF
--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -491,6 +491,10 @@ func (b *BlockWise) sendEntityIncomplete(w ResponseWriter, r Message, token mess
 	sendMessage := b.acquireMessage(w.Message().Context())
 	sendMessage.SetCode(codes.RequestEntityIncomplete)
 	sendMessage.SetToken(token)
+	if msg, ok := sendMessage.(hasType); ok {
+		msg.SetType(udpMessage.NonConfirmable)
+	}
+
 	setTypeFrom(sendMessage, r)
 	w.SetMessage(sendMessage)
 }
@@ -900,7 +904,6 @@ func (b *BlockWise) processReceivedMessage(w ResponseWriter, r Message, maxSzx S
 	szx = getSzx(szx, maxSzx)
 	sendMessage := b.acquireMessage(r.Context())
 	sendMessage.SetToken(token)
-	// TODO What to set type to?
 	if blockType == message.Block2 {
 		num = payloadSize / szx.Size()
 		sendMessage.ResetOptionsTo(sentRequest.Options())

--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -494,8 +494,6 @@ func (b *BlockWise) sendEntityIncomplete(w ResponseWriter, r Message, token mess
 	if msg, ok := sendMessage.(hasType); ok {
 		msg.SetType(udpMessage.NonConfirmable)
 	}
-
-	setTypeFrom(sendMessage, r)
 	w.SetMessage(sendMessage)
 }
 

--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -487,7 +487,7 @@ func (b *BlockWise) RemoveFromResponseCache(token message.Token) {
 	b.sendingMessagesCache.Delete(token.Hash())
 }
 
-func (b *BlockWise) sendEntityIncomplete(w ResponseWriter, r Message, token message.Token) {
+func (b *BlockWise) sendEntityIncomplete(w ResponseWriter, token message.Token) {
 	sendMessage := b.acquireMessage(w.Message().Context())
 	sendMessage.SetCode(codes.RequestEntityIncomplete)
 	sendMessage.SetToken(token)
@@ -507,7 +507,7 @@ func (b *BlockWise) Handle(w ResponseWriter, r Message, maxSZX SZX, maxMessageSi
 	if len(token) == 0 {
 		err := b.handleReceivedMessage(w, r, maxSZX, maxMessageSize, next)
 		if err != nil {
-			b.sendEntityIncomplete(w, r, token)
+			b.sendEntityIncomplete(w, token)
 			b.errors(fmt.Errorf("handleReceivedMessage(%v): %w", r, err))
 		}
 		return
@@ -519,7 +519,7 @@ func (b *BlockWise) Handle(w ResponseWriter, r Message, maxSZX SZX, maxMessageSi
 	if sendingMessageCached == nil {
 		err := b.handleReceivedMessage(w, r, maxSZX, maxMessageSize, next)
 		if err != nil {
-			b.sendEntityIncomplete(w, r, token)
+			b.sendEntityIncomplete(w, token)
 			b.errors(fmt.Errorf("handleReceivedMessage(%v): %w", r, err))
 		}
 		return


### PR DESCRIPTION
Hello!

While using this lib I discovered that observe requests sometimes wasn't retried properly ([here](https://github.com/plgd-dev/go-coap/blob/e59fa916285a183e0adbcbf6d0c2e1329ddc448e/udp/client/clientconn.go#L258)). After a bit of digging I found out that messages coming from the message pool always are set to non-confirmable while new messages not coming from the pool are confirmable by default.

Since the blockwise code copies messages it can end up sending a non-confirmable message when the original message was actually set as confirmable.

I am not very familiar with this code base so I am not sure this fix is good, I have tested it with our server and it seems to solve the issue.

To me it feels wrong to assume what the type should be, so I guess it needs to be set every time a message is acquired? Regardless if it is reused or new? I haven't checked the reset of the code base to see if there are more places like this, just this file. In the meantime I use a message pool with 0 max size as a workaround since most messages should be conformable anyway, but that could cause other issues I suppose, I mean I assume that reset sets a message to non-confirmable for a reason.

Cheers and thanks for a good library!