### PR TITLE
Update linters and fix reported issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,11 +98,13 @@ issues:
     - path: _test\.go
       linters:
         - dupl
+        - forcetypeassert
         - gosec
 
     - path: ^test/.*\.go
       linters:
         - dupl
+        - forcetypeassert
         - gosec
 
     - path: example_test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - bidichk          # Checks for dangerous unicode character sequences
     # - bodyclose        # checks whether HTTP response body is closed successfully
     # - contextcheck     # check the function whether use a non-inherited context
-    - deadcode         # Finds unused code
     - decorder         # check declaration order and count of types, constants, variables and functions
     - depguard         # Go linter that checks if package imports are in a list of acceptable packages
     - dogsled          # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
@@ -23,22 +22,22 @@ linters:
     # - exhaustive       # check exhaustiveness of enum switch statements
     - exportloopref    # checks for pointers to enclosing loop variables
     # - forbidigo        # Forbids identifiers
-    # - forcetypeassert  # finds forced type assertions
+    - forcetypeassert  # finds forced type assertions
     - gci              # Gci control golang package import order and make it always deterministic.
     # - gochecknoglobals # Checks that no globals are present in Go code
     # - gochecknoinits   # Checks that no init functions are present in Go code
     # - gocognit         # Computes and checks the cognitive complexity of functions
     - goconst          # Finds repeated strings that could be replaced by a constant
-    # - gocritic         # The most opinionated Go source code linter
-    # - gocyclo          # Computes and checks the cyclomatic complexity of functions
+    - gocritic         # The most opinionated Go source code linter
+    - gocyclo          # Computes and checks the cyclomatic complexity of functions
     # - godox            # Tool for detection of FIXME, TODO and other comment keywords
     # - goerr113         # Golang linter to check the errors handling expressions
     - gofmt            # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gofumpt          # Gofumpt checks whether code was gofumpt-ed.
     - goheader         # Checks is file header matches to pattern
     - goimports        # Goimports does everything that gofmt does. Additionally it checks unused imports
-    # - gomoddirectives  # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    # - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    - gomoddirectives  # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
+    - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
     - goprintffuncname # Checks that printf-like functions are named with `f` at the end
     - gosec            # Inspects source code for security problems
     - gosimple         # Linter for Go source code that specializes in simplifying a code
@@ -48,22 +47,21 @@ linters:
     - ineffassign      # Detects when assignments to existing variables are not used
     - misspell         # Finds commonly misspelled English words in comments
     # - nakedret         # Finds naked returns in functions greater than a specified function length
-    # - nilerr           # Finds the code that returns nil even if it checks that the error is not nil.
+    - nilerr           # Finds the code that returns nil even if it checks that the error is not nil.
     - nilnil           # Checks that there is no simultaneous return of `nil` error and an invalid value.
     # - noctx            # noctx finds sending http request without context.Context
     - nolintlint       # Reports ill-formed or insufficient nolint directives
     # - paralleltest     # paralleltest detects missing usage of t.Parallel() method in your Go test
     - predeclared      # find code that shadows one of Go's predeclared identifiers
-    # - revive           # golint replacement, finds style mistakes
+    - revive           # golint replacement, finds style mistakes
     - staticcheck      # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - stylecheck       # Stylecheck is a replacement for golint
     # - tenv             # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
     # - tparallel        # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
     - typecheck        # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert        # Remove unnecessary type conversions
-    # - unparam          # Reports unused function parameters
+    - unparam          # Reports unused function parameters
     - unused           # Checks Go code for unused constants, variables, functions and types
-    - varcheck         # Finds unused global variables and constants
     # - wastedassign     # wastedassign finds wasted assignment statements
     - whitespace       # Tool for detection of leading and trailing whitespace
   disable:
@@ -105,6 +103,16 @@ issues:
     - path: ^test/.*\.go
       linters:
         - dupl
+        - gosec
+
+    - path: example_test\.go
+      text: "exitAfterDefer"
+      linters:
+        - gocritic
+
+    - path: message/getmid.go
+      text: "G404: Use of weak random number generator \\(math/rand instead of crypto/rand\\)"
+      linters:
         - gosec
 
 #   # Fix found issues (if it's supported by the linter).

--- a/dtls/server/server.go
+++ b/dtls/server/server.go
@@ -94,24 +94,24 @@ func (s *Server) checkAndSetListener(l Listener) error {
 	return nil
 }
 
-func (s *Server) checkAcceptError(err error) (bool, error) {
+func (s *Server) checkAcceptError(err error) bool {
 	if err == nil {
-		return true, nil
+		return true
 	}
 	switch {
 	case errors.Is(err, coapNet.ErrListenerIsClosed):
 		s.Stop()
-		return false, nil
+		return false
 	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
 		select {
 		case <-s.ctx.Done():
 		default:
 			s.cfg.Errors(fmt.Errorf("cannot accept connection: %w", err))
-			return true, nil
+			return true
 		}
-		return false, nil
+		return false
 	default:
-		return true, nil
+		return true
 	}
 }
 
@@ -150,11 +150,7 @@ func (s *Server) Serve(l Listener) error {
 
 	for {
 		rw, err := l.AcceptWithContext(s.ctx)
-		ok, err := s.checkAcceptError(err)
-		if err != nil {
-			return err
-		}
-		if !ok {
+		if ok := s.checkAcceptError(err); !ok {
 			return nil
 		}
 		if rw == nil {

--- a/dtls/server/session.go
+++ b/dtls/server/session.go
@@ -19,7 +19,7 @@ type EventFunc = func()
 type Session struct {
 	onClose []EventFunc
 
-	ctx atomic.Value
+	ctx atomic.Value // TODO: change to atomic.Pointer[context.Context] for go1.19
 
 	cancel     context.CancelFunc
 	connection *coapNet.Conn
@@ -90,7 +90,7 @@ func (s *Session) Close() error {
 }
 
 func (s *Session) Context() context.Context {
-	return *s.ctx.Load().(*context.Context)
+	return *s.ctx.Load().(*context.Context) //nolint:forcetypeassert
 }
 
 // SetContextValue stores the value associated with key to context of connection.

--- a/message/encodeDecodeUint32.go
+++ b/message/encodeDecodeUint32.go
@@ -25,7 +25,7 @@ func EncodeUint32(buf []byte, value uint32) (int, error) {
 			return 3, ErrTooSmall
 		}
 		rv := make([]byte, 4)
-		binary.BigEndian.PutUint32(rv[:], value)
+		binary.BigEndian.PutUint32(rv, value)
 		copy(buf, rv[1:])
 		return 3, nil
 	default:

--- a/message/getmid.go
+++ b/message/getmid.go
@@ -24,7 +24,7 @@ func RandMID() int32 {
 	_, err := rand.Read(b)
 	if err != nil {
 		// fallback to cryptographically insecure pseudo-random generator
-		return int32(uint16(mathRand.Uint32() >> 16)) //nolint:gosec
+		return int32(uint16(mathRand.Uint32() >> 16))
 	}
 	return int32(uint16(binary.BigEndian.Uint32(b)))
 }

--- a/message/noresponse/noresponse_test.go
+++ b/message/noresponse/noresponse_test.go
@@ -27,7 +27,8 @@ func TestNoResponse5XXCodes(t *testing.T) {
 
 func TestNoResponseCombinationXXCodes(t *testing.T) {
 	codes := decodeNoResponseOption(18)
-	exp := append(resp2XXCodes, resp5XXCodes...)
+	exp := resp2XXCodes
+	exp = append(exp, resp5XXCodes...)
 	require.Equal(t, exp, codes)
 }
 

--- a/message/option.go
+++ b/message/option.go
@@ -393,7 +393,7 @@ func (o Option) Marshal(buf []byte, previousID OptionID) (int, error) {
 	default:
 		return -1, err
 	}
-	length = length + lenBuf
+	length += lenBuf
 
 	if buf == nil {
 		return length, ErrTooSmall
@@ -420,8 +420,8 @@ func parseExtOpt(data []byte, opt int) (int, int, error) {
 	return processed, opt, nil
 }
 
-func (o *Option) Unmarshal(data []byte, optionDefs map[OptionID]OptionDef, OptionID OptionID) (int, error) {
-	if def, ok := optionDefs[OptionID]; ok {
+func (o *Option) Unmarshal(data []byte, optionDefs map[OptionID]OptionDef, optionID OptionID) (int, error) {
+	if def, ok := optionDefs[optionID]; ok {
 		if def.ValueFormat == ValueUnknown {
 			// Skip unrecognized options (RFC7252 section 5.4.1)
 			return len(data), nil
@@ -431,7 +431,7 @@ func (o *Option) Unmarshal(data []byte, optionDefs map[OptionID]OptionDef, Optio
 			return len(data), nil
 		}
 	}
-	o.ID = OptionID
+	o.ID = optionID
 	proc, err := o.UnmarshalValue(data)
 	if err != nil {
 		return -1, err

--- a/message/option.go
+++ b/message/option.go
@@ -161,7 +161,7 @@ type MediaType uint16
 
 // Content formats.
 var (
-	TextPlain         MediaType = 0     // text/plain;charset=utf-8
+	TextPlain         MediaType         // text/plain;charset=utf-8
 	AppCoseEncrypt0   MediaType = 16    // application/cose; cose-type="cose-encrypt0" (RFC 8152)
 	AppCoseMac0       MediaType = 17    // application/cose; cose-type="cose-mac0" (RFC 8152)
 	AppCoseSign1      MediaType = 18    // application/cose; cose-type="cose-sign1" (RFC 8152)

--- a/message/options.go
+++ b/message/options.go
@@ -19,7 +19,7 @@ func GetPathBufferSize(path string) (int, error) {
 		subPath := path[start:]
 		segmentSize := strings.Index(subPath, "/")
 		if segmentSize == 0 {
-			start = start + 1
+			start++
 			continue
 		}
 		if segmentSize < 0 {
@@ -28,8 +28,8 @@ func GetPathBufferSize(path string) (int, error) {
 		if segmentSize > maxPathValue {
 			return -1, ErrInvalidValueLength
 		}
-		size = size + segmentSize
-		start = start + segmentSize + 1
+		size += segmentSize
+		start += segmentSize + 1
 	}
 	return size, nil
 }
@@ -54,7 +54,7 @@ func setPath(options Options, optionID OptionID, buf []byte, path string) (Optio
 		subPath := path[start:]
 		end := strings.Index(subPath, "/")
 		if end == 0 {
-			start = start + 1
+			start++
 			continue
 		}
 		if end < 0 {
@@ -68,7 +68,7 @@ func setPath(options Options, optionID OptionID, buf []byte, path string) (Optio
 			return o, -1, err
 		}
 		encoded += enc
-		start = start + end + 1
+		start += end + 1
 	}
 	return o, encoded, nil
 }
@@ -357,8 +357,8 @@ func (options Options) Accept() (MediaType, error) {
 }
 
 // Find returns range of type options. First number is index and second number is index of next option type.
-func (options Options) Find(ID OptionID) (int, int, error) {
-	idxPre, idxPost := options.findPosition(ID)
+func (options Options) Find(id OptionID) (int, int, error) {
+	idxPre, idxPost := options.findPosition(id)
 	if idxPre == -1 && idxPost == 0 {
 		return -1, -1, ErrOptionNotFound
 	}
@@ -368,7 +368,7 @@ func (options Options) Find(ID OptionID) (int, int, error) {
 	if idxPre < idxPost && idxPost-idxPre == 1 {
 		return -1, -1, ErrOptionNotFound
 	}
-	idxPre = idxPre + 1
+	idxPre++
 	if idxPost < 0 {
 		idxPost = len(options)
 	}
@@ -376,7 +376,7 @@ func (options Options) Find(ID OptionID) (int, int, error) {
 }
 
 // findPosition returns opened interval, -1 at means minIdx insert at 0, -1 maxIdx at maxIdx means append.
-func (options Options) findPosition(ID OptionID) (minIdx int, maxIdx int) {
+func (options Options) findPosition(id OptionID) (minIdx int, maxIdx int) {
 	if len(options) == 0 {
 		return -1, 0
 	}
@@ -385,19 +385,19 @@ func (options Options) findPosition(ID OptionID) (minIdx int, maxIdx int) {
 	minIdx = 0
 	for {
 		switch {
-		case ID == options[pivot].ID || (maxIdx-minIdx)/2 == 0:
-			for maxIdx = pivot; maxIdx < len(options) && options[maxIdx].ID <= ID; maxIdx++ {
+		case id == options[pivot].ID || (maxIdx-minIdx)/2 == 0:
+			for maxIdx = pivot; maxIdx < len(options) && options[maxIdx].ID <= id; maxIdx++ {
 			}
 			if maxIdx == len(options) {
 				maxIdx = -1
 			}
-			for minIdx = pivot; minIdx >= 0 && options[minIdx].ID >= ID; minIdx-- {
+			for minIdx = pivot; minIdx >= 0 && options[minIdx].ID >= id; minIdx-- {
 			}
 			return minIdx, maxIdx
-		case ID < options[pivot].ID:
+		case id < options[pivot].ID:
 			maxIdx = pivot
 			pivot = maxIdx - (maxIdx-minIdx)/2
-		case ID > options[pivot].ID:
+		case id > options[pivot].ID:
 			minIdx = pivot
 			pivot = minIdx + (maxIdx-minIdx)/2
 		}
@@ -482,8 +482,8 @@ func (options Options) Add(opt Option) Options {
 }
 
 // Remove removes all options with ID.
-func (options Options) Remove(ID OptionID) Options {
-	idxPre, idxPost, err := options.Find(ID)
+func (options Options) Remove(id OptionID) Options {
+	idxPre, idxPost, err := options.Find(id)
 	if err != nil {
 		return options
 	}
@@ -528,7 +528,7 @@ func (options Options) Marshal(buf []byte) (int, error) {
 		default:
 			return -1, err
 		}
-		length = length + optionLength
+		length += optionLength
 	}
 	if buf == nil {
 		return length, ErrTooSmall

--- a/message/pool/message_test.go
+++ b/message/pool/message_test.go
@@ -88,7 +88,7 @@ func TestMessageSetPathOptionLength(t *testing.T) {
 		outPath, err := msg.Path()
 		require.NoError(t, err)
 		require.Equal(t, net.NormalizeURLPath(inPath), outPath)
-		size = size * 4
+		size *= 4
 	}
 }
 
@@ -103,7 +103,7 @@ func TestMessageSetPathValidLength(t *testing.T) {
 		outPath, err := msg.Path()
 		require.NoError(t, err)
 		require.Equal(t, net.NormalizeURLPath(inPath), outPath)
-		size = size * 4
+		size *= 4
 	}
 }
 

--- a/message/pool/pool.go
+++ b/message/pool/pool.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"go.uber.org/atomic"
@@ -33,7 +34,10 @@ func (p *Pool) AcquireMessage(ctx context.Context) *Message {
 	if v == nil {
 		return NewMessage(ctx)
 	}
-	r := v.(*Message)
+	r, ok := v.(*Message)
+	if !ok {
+		panic(fmt.Errorf("invalid message type(%T) for pool", v))
+	}
 	p.currentMessagesInPool.Dec()
 	r.ctx = ctx
 	return r

--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -666,7 +666,9 @@ func copyToPayloadFromOffset(r *pool.Message, payloadFile *memfile.File, offset 
 	return payloadSize, nil
 }
 
+//nolint:gocyclo
 func (b *BlockWise[C]) processReceivedMessage(w *responsewriter.ResponseWriter[C], r *pool.Message, maxSzx SZX, next func(w *responsewriter.ResponseWriter[C], r *pool.Message), blockType message.OptionID, sizeType message.OptionID) error {
+	// TODO: lower cyclomatic complexity
 	token := r.Token()
 	if len(token) == 0 {
 		next(w, r)

--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -165,8 +165,16 @@ func NewUDPConn(network string, c *net.UDPConn, opts ...UDPOption) *UDPConn {
 		o.ApplyUDP(&cfg)
 	}
 
+	laddr := c.LocalAddr()
+	if laddr == nil {
+		panic(fmt.Errorf("invalid UDP connection"))
+	}
+	addr, ok := laddr.(*net.UDPAddr)
+	if !ok {
+		panic(fmt.Errorf("invalid address type(%T), UDP address expected", laddr))
+	}
 	var pc packetConn
-	if IsIPv6(c.LocalAddr().(*net.UDPAddr).IP) {
+	if IsIPv6(addr.IP) {
 		pc = newPacketConnIPv6(ipv6.NewPacketConn(c))
 	} else {
 		pc = newPacketConnIPv4(ipv4.NewPacketConn(c))

--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -283,7 +283,7 @@ func (c *UDPConn) WriteMulticast(ctx context.Context, raddr *net.UDPAddr, buffer
 	return c.writeMulticast(ctx, raddr, buffer, opt)
 }
 
-func (c *UDPConn) writeMulticastWithInterface(ctx context.Context, raddr *net.UDPAddr, buffer []byte, opt MulticastOptions) error {
+func (c *UDPConn) writeMulticastWithInterface(raddr *net.UDPAddr, buffer []byte, opt MulticastOptions) error {
 	if opt.Iface == nil && opt.IFaceMode == MulticastSpecificInterface {
 		return fmt.Errorf("invalid interface")
 	}
@@ -316,7 +316,7 @@ func (c *UDPConn) writeMulticastWithInterface(ctx context.Context, raddr *net.UD
 	return fmt.Errorf("%v", errors)
 }
 
-func (c *UDPConn) writeMulticastToAllInterfaces(ctx context.Context, raddr *net.UDPAddr, buffer []byte, opt MulticastOptions) error {
+func (c *UDPConn) writeMulticastToAllInterfaces(raddr *net.UDPAddr, buffer []byte, opt MulticastOptions) error {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return fmt.Errorf("cannot get interfaces for multicast connection: %w", err)
@@ -334,7 +334,7 @@ func (c *UDPConn) writeMulticastToAllInterfaces(ctx context.Context, raddr *net.
 		specificOpt := opt
 		specificOpt.Iface = &iface
 		specificOpt.IFaceMode = MulticastSpecificInterface
-		err = c.writeMulticastWithInterface(ctx, raddr, buffer, specificOpt)
+		err = c.writeMulticastWithInterface(raddr, buffer, specificOpt)
 		if err != nil {
 			if opt.InterfaceError != nil {
 				opt.InterfaceError(&iface, err)
@@ -352,7 +352,7 @@ func (c *UDPConn) writeMulticastToAllInterfaces(ctx context.Context, raddr *net.
 	return fmt.Errorf("%v", errors)
 }
 
-func (c *UDPConn) validateMulticast(ctx context.Context, raddr *net.UDPAddr, buffer []byte, opt MulticastOptions) error {
+func (c *UDPConn) validateMulticast(ctx context.Context, raddr *net.UDPAddr, opt MulticastOptions) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -371,14 +371,14 @@ func (c *UDPConn) validateMulticast(ctx context.Context, raddr *net.UDPAddr, buf
 }
 
 func (c *UDPConn) writeMulticast(ctx context.Context, raddr *net.UDPAddr, buffer []byte, opt MulticastOptions) error {
-	err := c.validateMulticast(ctx, raddr, buffer, opt)
+	err := c.validateMulticast(ctx, raddr, opt)
 	if err != nil {
 		return err
 	}
 
 	switch opt.IFaceMode {
 	case MulticastAllInterface:
-		err := c.writeMulticastToAllInterfaces(ctx, raddr, buffer, opt)
+		err := c.writeMulticastToAllInterfaces(raddr, buffer, opt)
 		if err != nil {
 			return fmt.Errorf("cannot write multicast to all interfaces: %w", err)
 		}
@@ -388,7 +388,7 @@ func (c *UDPConn) writeMulticast(ctx context.Context, raddr *net.UDPAddr, buffer
 			return fmt.Errorf("cannot write multicast to any: %w", err)
 		}
 	case MulticastSpecificInterface:
-		err := c.writeMulticastWithInterface(ctx, raddr, buffer, opt)
+		err := c.writeMulticastWithInterface(raddr, buffer, opt)
 		if err != nil {
 			if opt.InterfaceError != nil {
 				opt.InterfaceError(opt.Iface, err)

--- a/pkg/runner/periodic/periodic.go
+++ b/pkg/runner/periodic/periodic.go
@@ -23,7 +23,7 @@ func New(stop <-chan struct{}, tick time.Duration) Func {
 			}
 			v := make(map[uint64]func(time.Time) bool)
 			m.Range(func(key, value interface{}) bool {
-				v[key.(uint64)] = value.(func(time.Time) bool)
+				v[key.(uint64)] = value.(func(time.Time) bool) //nolint:forcetypeassert
 				return true
 			})
 			for k, f := range v {

--- a/tcp/client/session.go
+++ b/tcp/client/session.go
@@ -26,7 +26,7 @@ type Session struct {
 	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	sequence                        atomic.Uint64
 	onClose                         []EventFunc
-	ctx                             atomic.Value
+	ctx                             atomic.Value // // TODO: change to atomic.Pointer[context.Context] for go1.19
 	inactivityMonitor               InactivityMonitor
 	errSendCSM                      error
 	cancel                          context.CancelFunc
@@ -152,7 +152,7 @@ func (s *Session) Sequence() uint64 {
 }
 
 func (s *Session) Context() context.Context {
-	return *s.ctx.Load().(*context.Context)
+	return *s.ctx.Load().(*context.Context) //nolint:forcetypeassert
 }
 
 func (s *Session) PeerMaxMessageSize() uint32 {

--- a/tcp/server_test.go
+++ b/tcp/server_test.go
@@ -76,7 +76,7 @@ func TestServerCleanUpConns(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func createTLSConfig(ctx context.Context) (serverConfig *tls.Config, clientConfig *tls.Config, clientSerial *big.Int, err error) {
+func createTLSConfig() (serverConfig *tls.Config, clientConfig *tls.Config, clientSerial *big.Int, err error) {
 	// root cert
 	ca, rootBytes, _, caPriv, err := pki.GenerateCA()
 	if err != nil {
@@ -130,7 +130,7 @@ func createTLSConfig(ctx context.Context) (serverConfig *tls.Config, clientConfi
 func TestServerSetContextValueWithPKI(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	serverCgf, clientCgf, clientSerial, err := createTLSConfig(ctx)
+	serverCgf, clientCgf, clientSerial, err := createTLSConfig()
 	require.NoError(t, err)
 
 	ld, err := coapNet.NewTLSListener("tcp4", "", serverCgf)

--- a/udp/client.go
+++ b/udp/client.go
@@ -88,12 +88,12 @@ func Client(conn *net.UDPConn, opts ...Option) *client.ClientConn {
 	monitor := cfg.CreateInactivityMonitor()
 	l := coapNet.NewUDPConn(cfg.Net, conn, coapNet.WithErrors(cfg.Errors))
 	session := server.NewSession(cfg.Ctx,
+		context.Background(),
 		l,
 		addr,
 		cfg.MaxMessageSize,
 		cfg.MTU,
 		cfg.CloseSocket,
-		context.Background(),
 	)
 	cc := client.NewClientConn(session,
 		createBlockWise,

--- a/udp/client/clientconn.go
+++ b/udp/client/clientconn.go
@@ -384,7 +384,7 @@ func (cc *ClientConn) LocalAddr() net.Addr {
 	return cc.session.LocalAddr()
 }
 
-func (cc *ClientConn) sendPong(w *responsewriter.ResponseWriter[*ClientConn], r *pool.Message) {
+func (cc *ClientConn) sendPong(w *responsewriter.ResponseWriter[*ClientConn]) {
 	if err := w.SetResponse(codes.Empty, message.TextPlain, nil); err != nil {
 		cc.errors(fmt.Errorf("cannot send pong response: %w", err))
 	}
@@ -410,7 +410,7 @@ func (cc *ClientConn) handleBW(w *responsewriter.ResponseWriter[*ClientConn], m 
 
 func (cc *ClientConn) handle(w *responsewriter.ResponseWriter[*ClientConn], r *pool.Message) {
 	if r.Code() == codes.Empty && r.Type() == message.Confirmable && len(r.Token()) == 0 && len(r.Options()) == 0 && r.Body() == nil {
-		cc.sendPong(w, r)
+		cc.sendPong(w)
 		return
 	}
 	if h, ok := cc.midHandlerContainer.PullOut(r.MessageID()); ok {

--- a/udp/server/server.go
+++ b/udp/server/server.go
@@ -251,7 +251,7 @@ func getClose(cc *client.ClientConn) func() {
 	return v.(func())
 }
 
-func (s *Server) getOrCreateClientConn(UDPConn *coapNet.UDPConn, raddr *net.UDPAddr) (cc *client.ClientConn, created bool) {
+func (s *Server) getOrCreateClientConn(udpConn *coapNet.UDPConn, raddr *net.UDPAddr) (cc *client.ClientConn, created bool) {
 	s.connsMutex.Lock()
 	defer s.connsMutex.Unlock()
 	key := raddr.String()
@@ -286,7 +286,7 @@ func (s *Server) getOrCreateClientConn(UDPConn *coapNet.UDPConn, raddr *net.UDPA
 		}
 		session := NewSession(
 			s.ctx,
-			UDPConn,
+			udpConn,
 			raddr,
 			s.cfg.MaxMessageSize,
 			s.cfg.MTU,

--- a/udp/server/session.go
+++ b/udp/server/session.go
@@ -18,7 +18,7 @@ type EventFunc = func()
 type Session struct {
 	onClose []EventFunc
 
-	ctx atomic.Value
+	ctx atomic.Value // TODO: change to atomic.Pointer[context.Context] for go1.19
 
 	doneCtx    context.Context
 	connection *coapNet.UDPConn
@@ -36,12 +36,12 @@ type Session struct {
 
 func NewSession(
 	ctx context.Context,
+	doneCtx context.Context,
 	connection *coapNet.UDPConn,
 	raddr *net.UDPAddr,
 	maxMessageSize uint32,
 	mtu uint16,
 	closeSocket bool,
-	doneCtx context.Context,
 ) *Session {
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -103,7 +103,7 @@ func (s *Session) Close() error {
 }
 
 func (s *Session) Context() context.Context {
-	return *s.ctx.Load().(*context.Context)
+	return *s.ctx.Load().(*context.Context) //nolint:forcetypeassert
 }
 
 func (s *Session) WriteMessage(req *pool.Message) error {


### PR DESCRIPTION
Removed linters:
  - deadcode (obsolete)
  - varcheck (obsolete)

Enabled linters:
  - forcetypeassert
  - gocritic
  - gocyclo
  - gomoddirectives
  - gomodguard
  - nilerr
  - revive
  - unparam