### PR TITLE
fix returned block size in blockwise transfer

### DIFF
--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -401,13 +401,17 @@ func (b *BlockWise) WriteMessage(remoteAddr net.Addr, request Message, maxSZX SZ
 
 func fitSZX(r Message, blockType message.OptionID, maxSZX SZX) SZX {
 	block, err := r.GetOptionUint32(blockType)
-	if err == nil {
-		szx, _, _, err := DecodeBlockOption(block)
-		if err != nil {
-			if maxSZX > szx {
-				return szx
-			}
-		}
+	if err != nil {
+		return maxSZX
+	}
+
+	szx, _, _, err := DecodeBlockOption(block)
+	if err != nil {
+		return maxSZX
+	}
+
+	if maxSZX > szx {
+		return szx
 	}
 	return maxSZX
 }


### PR DESCRIPTION
Steps to reproduce:
1. Run a server for example on port 5688
2. Using coap client (https://libcoap.net/doc/reference/4.2.0/man_coap-client.html) run a request with giving block size, ex:
`coap-client -T token -b 16 -v 9 -m get 'coap://localhost:5688/a'`

Actual result:
Server ignores the Block2 option of 16 and returned whole response in single block as default server config is 1024 bytes SZX and this maxSZX from server is used instead of suggested size from client.

Expected result:
There should be multiple blocks with single block containing max 16 characters of transferred content as specified with flag "-b 16".