### PR TITLE
Fix off-by-one error in upserts

### DIFF
--- a/message/pool/message.go
+++ b/message/pool/message.go
@@ -81,7 +81,7 @@ func (r *Message) SetMessageID(mid int32) {
 
 // UpsertMessageID set value only when origin value is invalid. Only 0 to 2^16-1 values are valid.
 func (r *Message) UpsertMessageID(mid int32) {
-	if r.msg.MessageID >= 0 && r.msg.MessageID < math.MaxUint16 {
+	if r.msg.MessageID >= 0 && r.msg.MessageID <= math.MaxUint16 {
 		return
 	}
 	r.SetMessageID(mid)
@@ -99,7 +99,7 @@ func (r *Message) SetType(typ message.Type) {
 
 // UpsertType set value only when origin value is invalid. Only 0 to 2^8-1 values are valid.
 func (r *Message) UpsertType(typ message.Type) {
-	if r.msg.Type >= 0 && r.msg.Type < math.MaxUint8 {
+	if r.msg.Type >= 0 && r.msg.Type <= math.MaxUint8 {
 		return
 	}
 	r.SetType(typ)


### PR DESCRIPTION
There are two off-by-one errors in the upsert functions for message ID and message type.
`UpsertMessageId` should allow a value of 65535, while `UpsertType` should allow 255.

This fixes it, but I suspect it might break some tests or other things that rely on the existence of this bug (haven't tested). 

However, without this fix, a device sending a confirmable message to the server will recieve an ACK message back with an incorrect Message ID.