### PR TITLE
fix loss of order of messages

### DIFF
--- a/dtls/server/config.go
+++ b/dtls/server/config.go
@@ -19,8 +19,6 @@ type HandlerFunc = func(*responsewriter.ResponseWriter[*udpClient.Conn], *pool.M
 
 type ErrorFunc = func(error)
 
-type GoPoolFunc = config.GoPoolFunc[*udpClient.Conn]
-
 // OnNewConnFunc is the callback for new connections.
 type OnNewConnFunc = func(cc *udpClient.Conn)
 

--- a/dtls/server/server.go
+++ b/dtls/server/server.go
@@ -214,11 +214,12 @@ func (s *Server) createConn(connection *coapNet.Conn, monitor udpClient.Inactivi
 	cfg.TransmissionMaxRetransmit = s.cfg.TransmissionMaxRetransmit
 	cfg.Handler = s.cfg.Handler
 	cfg.BlockwiseSZX = s.cfg.BlockwiseSZX
-	cfg.GoPool = s.cfg.GoPool
 	cfg.Errors = s.cfg.Errors
 	cfg.GetMID = s.cfg.GetMID
 	cfg.GetToken = s.cfg.GetToken
 	cfg.MessagePool = s.cfg.MessagePool
+	cfg.ReceivedMessageQueueSize = s.cfg.ReceivedMessageQueueSize
+	cfg.ProcessReceivedMessage = s.cfg.ProcessReceivedMessage
 	cc := udpClient.NewConn(
 		session,
 		createBlockWise,

--- a/dtls/server_test.go
+++ b/dtls/server_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"math/big"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -20,9 +21,9 @@ import (
 	coapNet "github.com/plgd-dev/go-coap/v3/net"
 	"github.com/plgd-dev/go-coap/v3/net/responsewriter"
 	"github.com/plgd-dev/go-coap/v3/options"
-	"github.com/plgd-dev/go-coap/v3/options/config"
 	"github.com/plgd-dev/go-coap/v3/pkg/runner/periodic"
 	"github.com/plgd-dev/go-coap/v3/udp/client"
+	"github.com/plgd-dev/go-coap/v3/udp/coder"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"golang.org/x/sync/semaphore"
@@ -271,8 +272,8 @@ func TestServerKeepAliveMonitor(t *testing.T) {
 		require.NoError(t, errC)
 	}()
 
-	checkClose := semaphore.NewWeighted(2)
-	err = checkClose.Acquire(ctx, 2)
+	checkClose := semaphore.NewWeighted(1)
+	err = checkClose.Acquire(ctx, 1)
 	require.NoError(t, err)
 
 	sd := dtls.NewServer(
@@ -302,27 +303,22 @@ func TestServerKeepAliveMonitor(t *testing.T) {
 		require.NoError(t, errS)
 	}()
 
-	cc, err := dtls.Dial(
-		ld.Addr().String(),
-		clientCgf,
-		options.WithGoPool(func(processReqFunc config.ProcessRequestFunc[*client.Conn], req *pool.Message, cc *client.Conn, handler config.HandlerFunc[*client.Conn]) error {
-			time.Sleep(time.Millisecond * 500)
-			processReqFunc(req, cc, handler)
-			return nil
-		}),
-	)
-	require.NoError(t, err)
-	cc.AddOnClose(func() {
-		checkClose.Release(1)
-	})
-
-	// send ping to create serverside connection
-	ctxPing, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
-	err = cc.Ping(ctxPing)
+	cc, err := piondtls.Dial("udp", ld.Addr().(*net.UDPAddr), clientCgf)
 	require.NoError(t, err)
 
-	err = checkClose.Acquire(ctx, 2)
+	p := pool.NewMessage(ctx)
+	p.SetCode(codes.GET)
+	err = p.SetPath("/")
+	require.NoError(t, err)
+	p.SetMessageID(12345)
+	p.SetType(message.NonConfirmable)
+
+	data, err := p.MarshalWithEncoder(coder.DefaultCoder)
+	require.NoError(t, err)
+	_, err = cc.Write(data)
+	require.NoError(t, err)
+
+	err = checkClose.Acquire(ctx, 1)
 	require.NoError(t, err)
 	require.True(t, inactivityDetected.Load())
 }

--- a/message/pool/message.go
+++ b/message/pool/message.go
@@ -560,3 +560,14 @@ func (r *Message) SetupPut(path string, token message.Token, contentFormat messa
 func (r *Message) SetupDelete(path string, token message.Token, opts ...message.Option) error {
 	return r.setupCommon(codes.DELETE, path, token, opts...)
 }
+
+func (r *Message) Clone(p *Pool) *Message {
+	msg := p.AcquireMessage(r.Context())
+	msg.SetCode(r.Code())
+	msg.SetToken(r.Token())
+	msg.ResetOptionsTo(r.Options())
+	msg.SetType(r.Type())
+	msg.SetMessageID(r.MessageID())
+	msg.SetBody(r.Body())
+	return msg
+}

--- a/options/commonOptions.go
+++ b/options/commonOptions.go
@@ -213,70 +213,67 @@ func WithErrors(errors ErrorFunc) ErrorsOpt {
 	return ErrorsOpt{errors: errors}
 }
 
-// GoPoolOpt gopool option.
-type GoPoolOpt[C responsewriter.Client] struct {
-	goPool config.GoPoolFunc[C]
+// ProcessReceivedMessageOpt gopool option.
+type ProcessReceivedMessageOpt[C responsewriter.Client] struct {
+	ProcessReceivedMessageFunc config.ProcessReceivedMessageFunc[C]
 }
 
-func panicForInvalidGoPoolFunc(t, exp any) {
-	panic(fmt.Errorf("invalid GoPoolFunc type %T, expected %T", t, exp))
+func panicForInvalidProcessReceivedMessageFunc(t, exp any) {
+	panic(fmt.Errorf("invalid ProcessReceivedMessageFunc type %T, expected %T", t, exp))
 }
 
-func (o GoPoolOpt[C]) TCPServerApply(cfg *tcpServer.Config) {
-	switch v := any(o.goPool).(type) {
-	case config.GoPoolFunc[*tcpClient.Conn]:
-		cfg.GoPool = v
+func (o ProcessReceivedMessageOpt[C]) TCPServerApply(cfg *tcpServer.Config) {
+	switch v := any(o.ProcessReceivedMessageFunc).(type) {
+	case config.ProcessReceivedMessageFunc[*tcpClient.Conn]:
+		cfg.ProcessReceivedMessage = v
 	default:
-		var t config.GoPoolFunc[*tcpClient.Conn]
-		panicForInvalidGoPoolFunc(v, t)
+		var t config.ProcessReceivedMessageFunc[*tcpClient.Conn]
+		panicForInvalidProcessReceivedMessageFunc(v, t)
 	}
 }
 
-func (o GoPoolOpt[C]) TCPClientApply(cfg *tcpClient.Config) {
-	switch v := any(o.goPool).(type) {
-	case config.GoPoolFunc[*tcpClient.Conn]:
-		cfg.GoPool = v
+func (o ProcessReceivedMessageOpt[C]) TCPClientApply(cfg *tcpClient.Config) {
+	switch v := any(o.ProcessReceivedMessageFunc).(type) {
+	case config.ProcessReceivedMessageFunc[*tcpClient.Conn]:
+		cfg.ProcessReceivedMessage = v
 	default:
-		var t config.GoPoolFunc[*tcpClient.Conn]
-		panicForInvalidGoPoolFunc(v, t)
+		var t config.ProcessReceivedMessageFunc[*tcpClient.Conn]
+		panicForInvalidProcessReceivedMessageFunc(v, t)
 	}
 }
 
-func (o GoPoolOpt[C]) UDPServerApply(cfg *udpServer.Config) {
-	switch v := any(o.goPool).(type) {
-	case config.GoPoolFunc[*udpClient.Conn]:
-		cfg.GoPool = v
+func (o ProcessReceivedMessageOpt[C]) UDPServerApply(cfg *udpServer.Config) {
+	switch v := any(o.ProcessReceivedMessageFunc).(type) {
+	case config.ProcessReceivedMessageFunc[*udpClient.Conn]:
+		cfg.ProcessReceivedMessage = v
 	default:
-		var t config.GoPoolFunc[*udpClient.Conn]
-		panicForInvalidGoPoolFunc(v, t)
+		var t config.ProcessReceivedMessageFunc[*udpClient.Conn]
+		panicForInvalidProcessReceivedMessageFunc(v, t)
 	}
 }
 
-func (o GoPoolOpt[C]) DTLSServerApply(cfg *dtlsServer.Config) {
-	switch v := any(o.goPool).(type) {
-	case config.GoPoolFunc[*udpClient.Conn]:
-		cfg.GoPool = v
+func (o ProcessReceivedMessageOpt[C]) DTLSServerApply(cfg *dtlsServer.Config) {
+	switch v := any(o.ProcessReceivedMessageFunc).(type) {
+	case config.ProcessReceivedMessageFunc[*udpClient.Conn]:
+		cfg.ProcessReceivedMessage = v
 	default:
-		var t config.GoPoolFunc[*udpClient.Conn]
-		panicForInvalidGoPoolFunc(v, t)
+		var t config.ProcessReceivedMessageFunc[*udpClient.Conn]
+		panicForInvalidProcessReceivedMessageFunc(v, t)
 	}
 }
 
-func (o GoPoolOpt[C]) UDPClientApply(cfg *udpClient.Config) {
-	switch v := any(o.goPool).(type) {
-	case config.GoPoolFunc[*udpClient.Conn]:
-		cfg.GoPool = v
+func (o ProcessReceivedMessageOpt[C]) UDPClientApply(cfg *udpClient.Config) {
+	switch v := any(o.ProcessReceivedMessageFunc).(type) {
+	case config.ProcessReceivedMessageFunc[*udpClient.Conn]:
+		cfg.ProcessReceivedMessage = v
 	default:
-		var t config.GoPoolFunc[*udpClient.Conn]
-		panicForInvalidGoPoolFunc(v, t)
+		var t config.ProcessReceivedMessageFunc[*udpClient.Conn]
+		panicForInvalidProcessReceivedMessageFunc(v, t)
 	}
 }
 
-// WithGoPool sets function for managing spawning go routines
-// for handling incoming request's.
-// Eg: https://github.com/panjf2000/ants.
-func WithGoPool[C responsewriter.Client](goPool config.GoPoolFunc[C]) GoPoolOpt[C] {
-	return GoPoolOpt[C]{goPool: goPool}
+func WithProcessReceivedMessageFunc[C responsewriter.Client](processReceivedMessageFunc config.ProcessReceivedMessageFunc[C]) ProcessReceivedMessageOpt[C] {
+	return ProcessReceivedMessageOpt[C]{ProcessReceivedMessageFunc: processReceivedMessageFunc}
 }
 
 type (

--- a/tcp/client/conn.go
+++ b/tcp/client/conn.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/plgd-dev/go-coap/v3/message"
@@ -16,8 +17,9 @@ import (
 	limitparallelrequests "github.com/plgd-dev/go-coap/v3/net/client/limitParallelRequests"
 	"github.com/plgd-dev/go-coap/v3/net/observation"
 	"github.com/plgd-dev/go-coap/v3/net/responsewriter"
-	"github.com/plgd-dev/go-coap/v3/options/config"
 	coapErrors "github.com/plgd-dev/go-coap/v3/pkg/errors"
+	coapSync "github.com/plgd-dev/go-coap/v3/pkg/sync"
+	"go.uber.org/atomic"
 )
 
 type InactivityMonitor interface {
@@ -28,7 +30,6 @@ type InactivityMonitor interface {
 type (
 	HandlerFunc                 = func(*responsewriter.ResponseWriter[*Conn], *pool.Message)
 	ErrorFunc                   = func(error)
-	GoPoolFunc                  = config.GoPoolFunc[*Conn]
 	EventFunc                   = func()
 	GetMIDFunc                  = func() int32
 	CreateInactivityMonitorFunc = func() InactivityMonitor
@@ -41,8 +42,20 @@ type Notifier interface {
 // Conn represents a virtual connection to a conceptual endpoint, to perform COAPs commands.
 type Conn struct {
 	*client.Client[*Conn]
-	session            *Session
-	observationHandler *observation.Handler[*Conn]
+	session                         *Session
+	observationHandler              *observation.Handler[*Conn]
+	receivedMessageQueue            chan *pool.Message
+	processReceivedMessage          func(req *pool.Message, cc *Conn, handler HandlerFunc)
+	tokenHandlerContainer           *coapSync.Map[uint64, HandlerFunc]
+	blockWise                       *blockwise.BlockWise[*Conn]
+	blockwiseSZX                    blockwise.SZX
+	peerMaxMessageSize              atomic.Uint32
+	disablePeerTCPSignalMessageCSMs bool
+	peerBlockWiseTranferEnabled     atomic.Bool
+
+	loopOverReceivedMessageQueueMutex sync.Mutex
+	loopOverReceivedMessageQueueDone  chan struct{}
+	receivedMessageQueueReading       *atomic.Bool
 }
 
 // NewConn creates connection over session and observation.
@@ -55,20 +68,20 @@ func NewConn(
 	if cfg.GetToken == nil {
 		cfg.GetToken = message.GetToken
 	}
-	cc := Conn{}
+	cc := Conn{
+		receivedMessageQueue:            make(chan *pool.Message, cfg.ReceivedMessageQueueSize),
+		tokenHandlerContainer:           coapSync.NewMap[uint64, HandlerFunc](),
+		blockwiseSZX:                    cfg.BlockwiseSZX,
+		disablePeerTCPSignalMessageCSMs: cfg.DisablePeerTCPSignalMessageCSMs,
+	}
 	limitParallelRequests := limitparallelrequests.New(cfg.LimitClientParallelRequests, cfg.LimitClientEndpointParallelRequests, cc.do, cc.doObserve)
 	cc.observationHandler = observation.NewHandler(&cc, cfg.Handler, limitParallelRequests.Do)
 	cc.Client = client.New(&cc, cc.observationHandler, cfg.GetToken, limitParallelRequests)
-	blockWise := createBlockWise(&cc)
+	cc.blockWise = createBlockWise(&cc)
 	session := NewSession(cfg.Ctx,
 		connection,
-		cc.observationHandler.Handle,
 		cfg.MaxMessageSize,
-		cfg.GoPool,
 		cfg.Errors,
-		cfg.BlockwiseSZX,
-		blockWise,
-		cfg.DisablePeerTCPSignalMessageCSMs,
 		cfg.DisableTCPSignalMessageCSM,
 		cfg.CloseSocket,
 		inactivityMonitor,
@@ -76,7 +89,52 @@ func NewConn(
 		cfg.MessagePool,
 	)
 	cc.session = session
+	if cc.processReceivedMessage == nil {
+		cc.processReceivedMessage = processReceivedMessage
+	}
+	loopDone := make(chan struct{})
+	receivedMessageQueueReading := atomic.NewBool(true)
+	cc.loopOverReceivedMessageQueueDone = loopDone
+	cc.receivedMessageQueueReading = receivedMessageQueueReading
+	go cc.loopOverReceivedMessageQueue(loopDone, receivedMessageQueueReading)
 	return &cc
+}
+
+func processReceivedMessage(req *pool.Message, cc *Conn, handler HandlerFunc) {
+	cc.ProcessReceivedMessage(req, handler)
+}
+
+func (cc *Conn) loopOverReceivedMessageQueue(loopDone chan struct{}, reading *atomic.Bool) {
+	for {
+		reading.Store(true)
+		select {
+		case <-loopDone:
+			return
+		case <-cc.Done():
+			return
+		case req := <-cc.receivedMessageQueue:
+			reading.Store(false)
+			cc.processReceivedMessage(req, cc, cc.handle)
+		}
+	}
+}
+
+func (cc *Conn) trySpawnLoopOverReceivedMessageQueue() {
+	if cc.receivedMessageQueueReading.Load() {
+		return
+	}
+	cc.loopOverReceivedMessageQueueMutex.Lock()
+	if cc.receivedMessageQueueReading.Load() {
+		cc.loopOverReceivedMessageQueueMutex.Unlock()
+		return
+	}
+	defer cc.loopOverReceivedMessageQueueMutex.Unlock()
+	close(cc.loopOverReceivedMessageQueueDone)
+	loopDone := make(chan struct{})
+	receivedMessageQueueReading := atomic.NewBool(true)
+	cc.loopOverReceivedMessageQueueDone = loopDone
+	cc.receivedMessageQueueReading = receivedMessageQueueReading
+	go cc.loopOverReceivedMessageQueue(loopDone, receivedMessageQueueReading)
 }
 
 func (cc *Conn) Session() *Session {
@@ -98,7 +156,7 @@ func (cc *Conn) doInternal(req *pool.Message) (*pool.Message, error) {
 		return nil, fmt.Errorf("invalid token")
 	}
 	respChan := make(chan *pool.Message, 1)
-	if _, loaded := cc.session.TokenHandler().LoadOrStore(token.Hash(), func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
+	if _, loaded := cc.tokenHandlerContainer.LoadOrStore(token.Hash(), func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
 		r.Hijack()
 		select {
 		case respChan <- r:
@@ -108,11 +166,13 @@ func (cc *Conn) doInternal(req *pool.Message) (*pool.Message, error) {
 		return nil, fmt.Errorf("cannot add token handler: %w", coapErrors.ErrKeyAlreadyExists)
 	}
 	defer func() {
-		_, _ = cc.session.TokenHandler().LoadAndDelete(token.Hash())
+		_, _ = cc.tokenHandlerContainer.LoadAndDelete(token.Hash())
 	}()
 	if err := cc.session.WriteMessage(req); err != nil {
 		return nil, fmt.Errorf("cannot write request: %w", err)
 	}
+
+	cc.trySpawnLoopOverReceivedMessageQueue()
 
 	select {
 	case <-req.Context().Done():
@@ -131,10 +191,10 @@ func (cc *Conn) doInternal(req *pool.Message) (*pool.Message, error) {
 //
 // Caller is responsible to release request and response.
 func (cc *Conn) do(req *pool.Message) (*pool.Message, error) {
-	if !cc.session.PeerBlockWiseTransferEnabled() || cc.session.blockWise == nil {
+	if !cc.peerBlockWiseTranferEnabled.Load() || cc.blockWise == nil {
 		return cc.doInternal(req)
 	}
-	resp, err := cc.session.blockWise.Do(req, cc.session.blockwiseSZX, cc.session.maxMessageSize, cc.doInternal)
+	resp, err := cc.blockWise.Do(req, cc.blockwiseSZX, cc.session.maxMessageSize, cc.doInternal)
 	if err != nil {
 		return nil, err
 	}
@@ -147,10 +207,10 @@ func (cc *Conn) writeMessage(req *pool.Message) error {
 
 // WriteMessage sends an coap message.
 func (cc *Conn) WriteMessage(req *pool.Message) error {
-	if !cc.session.PeerBlockWiseTransferEnabled() || cc.session.blockWise == nil {
+	if !cc.peerBlockWiseTranferEnabled.Load() || cc.blockWise == nil {
 		return cc.writeMessage(req)
 	}
-	return cc.session.blockWise.WriteMessage(req, cc.session.blockwiseSZX, cc.session.maxMessageSize, cc.writeMessage)
+	return cc.blockWise.WriteMessage(req, cc.blockwiseSZX, cc.Session().maxMessageSize, cc.writeMessage)
 }
 
 // Context returns the client's context.
@@ -171,7 +231,7 @@ func (cc *Conn) AsyncPing(receivedPong func()) (func(), error) {
 	req.SetCode(codes.Ping)
 	defer cc.ReleaseMessage(req)
 
-	if _, loaded := cc.session.TokenHandler().LoadOrStore(token.Hash(), func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
+	if _, loaded := cc.tokenHandlerContainer.LoadOrStore(token.Hash(), func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
 		if r.Code() == codes.Pong {
 			receivedPong()
 		}
@@ -179,7 +239,7 @@ func (cc *Conn) AsyncPing(receivedPong func()) (func(), error) {
 		return nil, fmt.Errorf("cannot add token handler: %w", coapErrors.ErrKeyAlreadyExists)
 	}
 	removeTokenHandler := func() {
-		_, _ = cc.session.TokenHandler().LoadAndDelete(token.Hash())
+		_, _ = cc.tokenHandlerContainer.LoadAndDelete(token.Hash())
 	}
 	err = cc.session.WriteMessage(req)
 	if err != nil {
@@ -226,6 +286,9 @@ func (cc *Conn) Done() <-chan struct{} {
 // CheckExpirations checks and remove expired items from caches.
 func (cc *Conn) CheckExpirations(now time.Time) {
 	cc.session.CheckExpirations(now, cc)
+	if cc.blockWise != nil {
+		cc.blockWise.CheckExpirations(now)
+	}
 }
 
 func (cc *Conn) AcquireMessage(ctx context.Context) *pool.Message {
@@ -244,4 +307,102 @@ func (cc *Conn) NetConn() net.Conn {
 // DoObserve subscribes for every change with request.
 func (cc *Conn) doObserve(req *pool.Message, observeFunc func(req *pool.Message), opts ...message.Option) (client.Observation, error) {
 	return cc.observationHandler.NewObservation(req, observeFunc)
+}
+
+func (cc *Conn) ProcessReceivedMessage(req *pool.Message, handler HandlerFunc) {
+	origResp := cc.AcquireMessage(cc.Context())
+	origResp.SetToken(req.Token())
+	w := responsewriter.New(origResp, cc, req.Options()...)
+	handler(w, req)
+	defer cc.ReleaseMessage(w.Message())
+	if !req.IsHijacked() {
+		cc.ReleaseMessage(req)
+	}
+	if w.Message().IsModified() {
+		err := cc.Session().WriteMessage(w.Message())
+		if err != nil {
+			if errC := cc.Close(); errC != nil {
+				cc.Session().errors(fmt.Errorf("cannot close connection: %w", errC))
+			}
+			cc.Session().errors(fmt.Errorf("cannot write response to %v: %w", cc.RemoteAddr(), err))
+		}
+	}
+}
+
+func (cc *Conn) blockwiseHandle(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
+	if h, ok := cc.tokenHandlerContainer.Load(r.Token().Hash()); ok {
+		h(w, r)
+		return
+	}
+	cc.observationHandler.Handle(w, r)
+}
+
+func (cc *Conn) handle(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
+	if cc.blockWise != nil && cc.peerBlockWiseTranferEnabled.Load() {
+		cc.blockWise.Handle(w, r, cc.blockwiseSZX, cc.Session().maxMessageSize, cc.blockwiseHandle)
+		return
+	}
+	if h, ok := cc.tokenHandlerContainer.LoadAndDelete(r.Token().Hash()); ok {
+		h(w, r)
+		return
+	}
+	cc.observationHandler.Handle(w, r)
+}
+
+func (cc *Conn) sendPong(token message.Token) error {
+	req := cc.AcquireMessage(cc.Context())
+	defer cc.ReleaseMessage(req)
+	req.SetCode(codes.Pong)
+	req.SetToken(token)
+	return cc.Session().WriteMessage(req)
+}
+
+func (cc *Conn) handleSignals(r *pool.Message) bool {
+	switch r.Code() {
+	case codes.CSM:
+		if cc.disablePeerTCPSignalMessageCSMs {
+			return true
+		}
+		if size, err := r.GetOptionUint32(message.TCPMaxMessageSize); err == nil {
+			cc.peerMaxMessageSize.Store(size)
+		}
+		if r.HasOption(message.TCPBlockWiseTransfer) {
+			cc.peerBlockWiseTranferEnabled.Store(true)
+		}
+		return true
+	case codes.Ping:
+		// if r.HasOption(message.TCPCustody) {
+		// TODO
+		// }
+		if err := cc.sendPong(r.Token()); err != nil && !coapNet.IsConnectionBrokenError(err) {
+			cc.Session().errors(fmt.Errorf("cannot handle ping signal: %w", err))
+		}
+		return true
+	case codes.Release:
+		// if r.HasOption(message.TCPAlternativeAddress) {
+		// TODO
+		// }
+		return true
+	case codes.Abort:
+		// if r.HasOption(message.TCPBadCSMOption) {
+		// TODO
+		// }
+		return true
+	case codes.Pong:
+		if h, ok := cc.tokenHandlerContainer.LoadAndDelete(r.Token().Hash()); ok {
+			cc.processReceivedMessage(r, cc, h)
+		}
+		return true
+	}
+	return false
+}
+
+func (cc *Conn) pushToReceivedMessageQueue(r *pool.Message) {
+	if cc.handleSignals(r) {
+		return
+	}
+	select {
+	case cc.receivedMessageQueue <- r:
+	case <-cc.Context().Done():
+	}
 }

--- a/tcp/client/session.go
+++ b/tcp/client/session.go
@@ -13,11 +13,7 @@ import (
 	"github.com/plgd-dev/go-coap/v3/message/codes"
 	"github.com/plgd-dev/go-coap/v3/message/pool"
 	coapNet "github.com/plgd-dev/go-coap/v3/net"
-	"github.com/plgd-dev/go-coap/v3/net/blockwise"
 	"github.com/plgd-dev/go-coap/v3/net/monitor/inactivity"
-	"github.com/plgd-dev/go-coap/v3/net/responsewriter"
-	"github.com/plgd-dev/go-coap/v3/options/config"
-	coapSync "github.com/plgd-dev/go-coap/v3/pkg/sync"
 	"github.com/plgd-dev/go-coap/v3/tcp/coder"
 	"go.uber.org/atomic"
 )
@@ -25,41 +21,29 @@ import (
 type Session struct {
 	// This field needs to be the first in the struct to ensure proper word alignment on 32-bit platforms.
 	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
-	sequence                        atomic.Uint64
-	onClose                         []EventFunc
-	ctx                             atomic.Value // // TODO: change to atomic.Pointer[context.Context] for go1.19
-	inactivityMonitor               InactivityMonitor
-	errSendCSM                      error
-	cancel                          context.CancelFunc
-	done                            chan struct{}
-	goPool                          GoPoolFunc
-	errors                          ErrorFunc
-	blockWise                       *blockwise.BlockWise[*Conn]
-	connection                      *coapNet.Conn
-	handler                         func(*responsewriter.ResponseWriter[*Conn], *pool.Message)
-	tokenHandlerContainer           *coapSync.Map[uint64, func(*responsewriter.ResponseWriter[*Conn], *pool.Message)]
-	messagePool                     *pool.Pool
-	mutex                           sync.Mutex
-	maxMessageSize                  uint32
-	peerBlockWiseTranferEnabled     atomic.Bool
-	peerMaxMessageSize              atomic.Uint32
-	connectionCacheSize             uint16
-	disableTCPSignalMessageCSM      bool
-	disablePeerTCPSignalMessageCSMs bool
-	blockwiseSZX                    blockwise.SZX
-	closeSocket                     bool
+	sequence          atomic.Uint64
+	onClose           []EventFunc
+	ctx               atomic.Value // // TODO: change to atomic.Pointer[context.Context] for go1.19
+	inactivityMonitor InactivityMonitor
+	errSendCSM        error
+	cancel            context.CancelFunc
+	done              chan struct{}
+	errors            ErrorFunc
+	connection        *coapNet.Conn
+	messagePool       *pool.Pool
+	mutex             sync.Mutex
+	maxMessageSize    uint32
+
+	connectionCacheSize        uint16
+	disableTCPSignalMessageCSM bool
+	closeSocket                bool
 }
 
 func NewSession(
 	ctx context.Context,
 	connection *coapNet.Conn,
-	handler HandlerFunc,
 	maxMessageSize uint32,
-	goPool GoPoolFunc,
 	errors ErrorFunc,
-	blockwiseSZX blockwise.SZX,
-	blockWise *blockwise.BlockWise[*Conn],
-	disablePeerTCPSignalMessageCSMs bool,
 	disableTCPSignalMessageCSM bool,
 	closeSocket bool,
 	inactivityMonitor InactivityMonitor,
@@ -77,22 +61,16 @@ func NewSession(
 	}
 
 	s := &Session{
-		cancel:                          cancel,
-		connection:                      connection,
-		handler:                         handler,
-		maxMessageSize:                  maxMessageSize,
-		tokenHandlerContainer:           coapSync.NewMap[uint64, HandlerFunc](),
-		goPool:                          goPool,
-		errors:                          errors,
-		blockWise:                       blockWise,
-		blockwiseSZX:                    blockwiseSZX,
-		disablePeerTCPSignalMessageCSMs: disablePeerTCPSignalMessageCSMs,
-		disableTCPSignalMessageCSM:      disableTCPSignalMessageCSM,
-		closeSocket:                     closeSocket,
-		inactivityMonitor:               inactivityMonitor,
-		done:                            make(chan struct{}),
-		connectionCacheSize:             connectionCacheSize,
-		messagePool:                     messagePool,
+		cancel:                     cancel,
+		connection:                 connection,
+		maxMessageSize:             maxMessageSize,
+		errors:                     errors,
+		disableTCPSignalMessageCSM: disableTCPSignalMessageCSM,
+		closeSocket:                closeSocket,
+		inactivityMonitor:          inactivityMonitor,
+		done:                       make(chan struct{}),
+		connectionCacheSize:        connectionCacheSize,
+		messagePool:                messagePool,
 	}
 	s.ctx.Store(&ctx)
 
@@ -156,98 +134,6 @@ func (s *Session) Context() context.Context {
 	return *s.ctx.Load().(*context.Context) //nolint:forcetypeassert
 }
 
-func (s *Session) PeerMaxMessageSize() uint32 {
-	return s.peerMaxMessageSize.Load()
-}
-
-func (s *Session) PeerBlockWiseTransferEnabled() bool {
-	return s.peerBlockWiseTranferEnabled.Load()
-}
-
-func (s *Session) handleSignals(r *pool.Message, cc *Conn) bool {
-	switch r.Code() {
-	case codes.CSM:
-		if s.disablePeerTCPSignalMessageCSMs {
-			return true
-		}
-		if size, err := r.GetOptionUint32(message.TCPMaxMessageSize); err == nil {
-			s.peerMaxMessageSize.Store(size)
-		}
-		if r.HasOption(message.TCPBlockWiseTransfer) {
-			s.peerBlockWiseTranferEnabled.Store(true)
-		}
-		return true
-	case codes.Ping:
-		// if r.HasOption(message.TCPCustody) {
-		// TODO
-		// }
-		if err := s.sendPong(r.Token()); err != nil && !coapNet.IsConnectionBrokenError(err) {
-			s.errors(fmt.Errorf("cannot handle ping signal: %w", err))
-		}
-		return true
-	case codes.Release:
-		// if r.HasOption(message.TCPAlternativeAddress) {
-		// TODO
-		// }
-		return true
-	case codes.Abort:
-		// if r.HasOption(message.TCPBadCSMOption) {
-		// TODO
-		// }
-		return true
-	case codes.Pong:
-		if h, ok := s.tokenHandlerContainer.LoadAndDelete(r.Token().Hash()); ok {
-			s.processReq(r, cc, h)
-		}
-		return true
-	}
-	return false
-}
-
-func (s *Session) blockwiseHandle(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
-	if h, ok := s.tokenHandlerContainer.Load(r.Token().Hash()); ok {
-		h(w, r)
-		return
-	}
-	s.handler(w, r)
-}
-
-func (s *Session) Handle(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
-	if s.blockWise != nil && s.PeerBlockWiseTransferEnabled() {
-		s.blockWise.Handle(w, r, s.blockwiseSZX, s.maxMessageSize, s.blockwiseHandle)
-		return
-	}
-	if h, ok := s.tokenHandlerContainer.LoadAndDelete(r.Token().Hash()); ok {
-		h(w, r)
-		return
-	}
-	s.handler(w, r)
-}
-
-func (s *Session) TokenHandler() *coapSync.Map[uint64, HandlerFunc] {
-	return s.tokenHandlerContainer
-}
-
-func (s *Session) processReq(req *pool.Message, cc *Conn, handler config.HandlerFunc[*Conn]) {
-	origResp := s.messagePool.AcquireMessage(s.Context())
-	origResp.SetToken(req.Token())
-	w := responsewriter.New(origResp, cc, req.Options()...)
-	handler(w, req)
-	defer s.messagePool.ReleaseMessage(w.Message())
-	if !req.IsHijacked() {
-		s.messagePool.ReleaseMessage(req)
-	}
-	if w.Message().IsModified() {
-		err := s.WriteMessage(w.Message())
-		if err != nil {
-			if errC := s.Close(); errC != nil {
-				s.errors(fmt.Errorf("cannot close connection: %w", errC))
-			}
-			s.errors(fmt.Errorf("cannot write response to %v: %w", s.connection.RemoteAddr(), err))
-		}
-	}
-}
-
 func seekBufferToNextMessage(buffer *bytes.Buffer, msgSize int) *bytes.Buffer {
 	if msgSize == buffer.Len() {
 		// buffer is empty so reset it
@@ -290,13 +176,7 @@ func (s *Session) processBuffer(buffer *bytes.Buffer, cc *Conn) error {
 		buffer = seekBufferToNextMessage(buffer, read)
 		req.SetSequence(s.Sequence())
 		s.inactivityMonitor.Notify()
-		if s.handleSignals(req, cc) {
-			continue
-		}
-		err = s.goPool(s.processReq, req, cc, s.Handle)
-		if err != nil {
-			return fmt.Errorf("cannot spawn go routine: %w", err)
-		}
+		cc.pushToReceivedMessageQueue(req)
 	}
 	return nil
 }
@@ -321,14 +201,6 @@ func (s *Session) sendCSM() error {
 	req := s.messagePool.AcquireMessage(s.Context())
 	defer s.messagePool.ReleaseMessage(req)
 	req.SetCode(codes.CSM)
-	req.SetToken(token)
-	return s.WriteMessage(req)
-}
-
-func (s *Session) sendPong(token message.Token) error {
-	req := s.messagePool.AcquireMessage(s.Context())
-	defer s.messagePool.ReleaseMessage(req)
-	req.SetCode(codes.Pong)
 	req.SetToken(token)
 	return s.WriteMessage(req)
 }
@@ -376,9 +248,6 @@ func (s *Session) Run(cc *Conn) (err error) {
 // CheckExpirations checks and remove expired items from caches.
 func (s *Session) CheckExpirations(now time.Time, cc *Conn) {
 	s.inactivityMonitor.CheckInactivity(now, cc)
-	if s.blockWise != nil {
-		s.blockWise.CheckExpirations(now)
-	}
 }
 
 func (s *Session) AcquireMessage(ctx context.Context) *pool.Message {

--- a/tcp/server/server.go
+++ b/tcp/server/server.go
@@ -202,7 +202,6 @@ func (s *Server) createConn(connection *coapNet.Conn, monitor client.InactivityM
 	cfg.Ctx = s.ctx
 	cfg.Handler = s.cfg.Handler
 	cfg.MaxMessageSize = s.cfg.MaxMessageSize
-	cfg.GoPool = s.cfg.GoPool
 	cfg.Errors = s.cfg.Errors
 	cfg.BlockwiseSZX = s.cfg.BlockwiseSZX
 	cfg.DisablePeerTCPSignalMessageCSMs = s.cfg.DisablePeerTCPSignalMessageCSMs
@@ -211,6 +210,8 @@ func (s *Server) createConn(connection *coapNet.Conn, monitor client.InactivityM
 	cfg.ConnectionCacheSize = s.cfg.ConnectionCacheSize
 	cfg.MessagePool = s.cfg.MessagePool
 	cfg.GetToken = s.cfg.GetToken
+	cfg.ProcessReceivedMessage = s.cfg.ProcessReceivedMessage
+	cfg.ReceivedMessageQueueSize = s.cfg.ReceivedMessageQueueSize
 	cc := client.NewConn(
 		connection,
 		createBlockWise,

--- a/udp/client/conn.go
+++ b/udp/client/conn.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/plgd-dev/go-coap/v3/message"
@@ -33,7 +34,6 @@ const ExchangeLifetime = 247 * time.Second
 type (
 	HandlerFunc                 = func(*responsewriter.ResponseWriter[*Conn], *pool.Message)
 	ErrorFunc                   = func(error)
-	GoPoolFunc                  = config.GoPoolFunc[*Conn]
 	EventFunc                   = func()
 	GetMIDFunc                  = func() int32
 	CreateInactivityMonitorFunc = func() InactivityMonitor
@@ -70,6 +70,55 @@ const (
 	errFmtWriteResponse = "cannot write response: %w"
 )
 
+type midElement struct {
+	handler    HandlerFunc
+	start      time.Time
+	deadline   time.Time
+	retransmit atomic.Int32
+
+	private struct {
+		sync.Mutex
+		msg *pool.Message
+	}
+}
+
+func (m *midElement) ReleaseMessage(cc *Conn) {
+	m.private.Lock()
+	defer m.private.Unlock()
+	if m.private.msg != nil {
+		cc.ReleaseMessage(m.private.msg)
+		m.private.msg = nil
+	}
+}
+
+func (m *midElement) IsExpired(now time.Time, maxRetransmit int32) bool {
+	if !m.deadline.IsZero() && now.After(m.deadline) {
+		// remove element if deadline is exceeded
+		return true
+	}
+	retransmit := m.retransmit.Load()
+	return retransmit >= maxRetransmit
+}
+
+func (m *midElement) Retransmit(now time.Time, acknowledgeTimeout time.Duration) bool {
+	if now.After(m.start.Add(acknowledgeTimeout * time.Duration(m.retransmit.Load()+1))) {
+		m.retransmit.Inc()
+		// retransmit
+		return true
+	}
+	// wait for next retransmit
+	return false
+}
+
+func (m *midElement) GetMessage(cc *Conn) (*pool.Message, bool) {
+	m.private.Lock()
+	defer m.private.Unlock()
+	if m.private.msg == nil {
+		return nil, false
+	}
+	return m.private.msg.Clone(cc.messagePool), true
+}
+
 // Conn represents a virtual connection to a conceptual endpoint, to perform COAPs commands.
 type Conn struct {
 	// This field needs to be the first in the struct to ensure proper word alignment on 32-bit platforms.
@@ -85,13 +134,13 @@ type Conn struct {
 	transmission       *Transmission
 	messagePool        *pool.Pool
 
-	goPool           GoPoolFunc
-	errors           ErrorFunc
-	responseMsgCache *cache.Cache[string, []byte]
-	msgIDMutex       *MutexMap
+	processReceivedMessage config.ProcessReceivedMessageFunc[*Conn]
+	errors                 ErrorFunc
+	responseMsgCache       *cache.Cache[string, []byte]
+	msgIDMutex             *MutexMap
 
 	tokenHandlerContainer *coapSync.Map[uint64, HandlerFunc]
-	midHandlerContainer   *coapSync.Map[int32, HandlerFunc]
+	midHandlerContainer   *coapSync.Map[int32, *midElement]
 	msgID                 atomic.Uint32
 	blockwiseSZX          blockwise.SZX
 
@@ -103,6 +152,12 @@ type Conn struct {
 		time, counting as one outstanding interaction).
 	*/
 	numOutstandingInteraction *semaphore.Weighted
+
+	receivedMessageQueue chan *pool.Message
+
+	loopOverReceivedMessageQueueMutex sync.Mutex
+	loopOverReceivedMessageQueueDone  chan struct{}
+	receivedMessageQueueReading       *atomic.Bool
 }
 
 // Transmission is a threadsafe container for transmission related parameters
@@ -147,6 +202,9 @@ func NewConn(
 	if cfg.GetToken == nil {
 		cfg.GetToken = message.GetToken
 	}
+	if cfg.ReceivedMessageQueueSize < 0 {
+		cfg.ReceivedMessageQueueSize = 0
+	}
 
 	cc := Conn{
 		session: session,
@@ -158,21 +216,49 @@ func NewConn(
 		blockwiseSZX: cfg.BlockwiseSZX,
 
 		tokenHandlerContainer:     coapSync.NewMap[uint64, HandlerFunc](),
-		midHandlerContainer:       coapSync.NewMap[int32, HandlerFunc](),
-		goPool:                    cfg.GoPool,
+		midHandlerContainer:       coapSync.NewMap[int32, *midElement](),
+		processReceivedMessage:    cfg.ProcessReceivedMessage,
 		errors:                    cfg.Errors,
 		msgIDMutex:                NewMutexMap(),
 		responseMsgCache:          cache.NewCache[string, []byte](),
 		inactivityMonitor:         inactivityMonitor,
 		messagePool:               cfg.MessagePool,
 		numOutstandingInteraction: semaphore.NewWeighted(math.MaxInt64),
+		receivedMessageQueue:      make(chan *pool.Message, cfg.ReceivedMessageQueueSize),
 	}
 	cc.msgID.Store(uint32(cfg.GetMID() - 0xffff/2))
 	cc.blockWise = createBlockWise(&cc)
 	limitParallelRequests := limitparallelrequests.New(cfg.LimitClientParallelRequests, cfg.LimitClientEndpointParallelRequests, cc.do, cc.doObserve)
 	cc.observationHandler = observation.NewHandler(&cc, cfg.Handler, limitParallelRequests.Do)
 	cc.Client = client.New(&cc, cc.observationHandler, cfg.GetToken, limitParallelRequests)
+	if cc.processReceivedMessage == nil {
+		cc.processReceivedMessage = processReceivedMessage
+	}
+	loopDone := make(chan struct{})
+	receivedMessageQueueReading := atomic.NewBool(true)
+	cc.loopOverReceivedMessageQueueDone = loopDone
+	cc.receivedMessageQueueReading = receivedMessageQueueReading
+	go cc.loopOverReceivedMessageQueue(loopDone, receivedMessageQueueReading)
 	return &cc
+}
+
+func processReceivedMessage(req *pool.Message, cc *Conn, handler config.HandlerFunc[*Conn]) {
+	cc.ProcessMessage(req, handler)
+}
+
+func (cc *Conn) loopOverReceivedMessageQueue(loopDone chan struct{}, reading *atomic.Bool) {
+	for {
+		reading.Store(true)
+		select {
+		case <-loopDone:
+			return
+		case <-cc.Done():
+			return
+		case req := <-cc.receivedMessageQueue:
+			reading.Store(false)
+			cc.processReceivedMessage(req, cc, cc.handleReq)
+		}
+	}
 }
 
 func (cc *Conn) Session() Session {
@@ -190,6 +276,24 @@ func (cc *Conn) Close() error {
 		return nil
 	}
 	return err
+}
+
+func (cc *Conn) trySpawnLoopOverReceivedMessageQueue() {
+	if cc.receivedMessageQueueReading.Load() {
+		return
+	}
+	cc.loopOverReceivedMessageQueueMutex.Lock()
+	if cc.receivedMessageQueueReading.Load() {
+		cc.loopOverReceivedMessageQueueMutex.Unlock()
+		return
+	}
+	defer cc.loopOverReceivedMessageQueueMutex.Unlock()
+	close(cc.loopOverReceivedMessageQueueDone)
+	loopDone := make(chan struct{})
+	receivedMessageQueueReading := atomic.NewBool(true)
+	cc.loopOverReceivedMessageQueueDone = loopDone
+	cc.receivedMessageQueueReading = receivedMessageQueueReading
+	go cc.loopOverReceivedMessageQueue(loopDone, receivedMessageQueueReading)
 }
 
 func (cc *Conn) doInternal(req *pool.Message) (*pool.Message, error) {
@@ -215,10 +319,11 @@ func (cc *Conn) doInternal(req *pool.Message) (*pool.Message, error) {
 	if err != nil {
 		return nil, fmt.Errorf(errFmtWriteRequest, err)
 	}
+	cc.trySpawnLoopOverReceivedMessageQueue()
 	select {
 	case <-req.Context().Done():
 		return nil, req.Context().Err()
-	case <-cc.session.Context().Done():
+	case <-cc.Context().Done():
 		return nil, fmt.Errorf("connection was closed: %w", cc.session.Context().Err())
 	case resp := <-respChan:
 		return resp, nil
@@ -270,26 +375,19 @@ func (cc *Conn) acquireOutstandingInteraction(ctx context.Context) error {
 	return nil
 }
 
-func (cc *Conn) transmitMessage(req *pool.Message, waitForResponseChan chan struct{}) error {
-	maxRetransmit := cc.transmission.maxRetransmit.Load()
-	for i := int32(0); i < maxRetransmit; i++ {
-		select {
-		case <-waitForResponseChan:
-			return nil
-		case <-req.Context().Done():
-			return req.Context().Err()
-		case <-cc.Context().Done():
-			return fmt.Errorf("connection was closed: %w", cc.Context().Err())
-		case <-time.After(cc.transmission.acknowledgeTimeout.Load()):
-			if err := cc.session.WriteMessage(req); err != nil {
-				return err
-			}
-		}
+func (cc *Conn) waitForAcknowledge(req *pool.Message, waitForResponseChan chan struct{}) error {
+	cc.trySpawnLoopOverReceivedMessageQueue()
+	select {
+	case <-waitForResponseChan:
+		return nil
+	case <-req.Context().Done():
+		return req.Context().Err()
+	case <-cc.Context().Done():
+		return fmt.Errorf("connection was closed: %w", cc.Context().Err())
 	}
-	return fmt.Errorf("timeout: retransmission(%v) was exhausted", cc.transmission.maxRetransmit.Load())
 }
 
-func (cc *Conn) prepareWriteMessage(req *pool.Message, respChan chan struct{}) (func(), error) {
+func (cc *Conn) prepareWriteMessage(req *pool.Message, handler HandlerFunc) (func(), error) {
 	var closeFns fn.FuncList
 
 	// Only confirmable messages ever match an message ID
@@ -303,13 +401,15 @@ func (cc *Conn) prepareWriteMessage(req *pool.Message, respChan chan struct{}) (
 				cc.releaseOutstandingInteraction()
 			})
 		}
-		if _, loaded := cc.midHandlerContainer.LoadOrStore(req.MessageID(), func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
-			close(respChan)
-			if r.IsSeparateMessage() {
-				// separate message - just accept
-				return
-			}
-			cc.handleBW(w, r)
+		deadline, _ := req.Context().Deadline()
+		if _, loaded := cc.midHandlerContainer.LoadOrStore(req.MessageID(), &midElement{
+			handler:  handler,
+			start:    time.Now(),
+			deadline: deadline,
+			private: struct {
+				sync.Mutex
+				msg *pool.Message
+			}{msg: req.Clone(cc.messagePool)},
 		}); loaded {
 			closeFns.Execute()
 			return nil, fmt.Errorf("cannot insert mid(%v) handler: %w", req.MessageID(), coapErrors.ErrKeyAlreadyExists)
@@ -326,27 +426,40 @@ func (cc *Conn) prepareWriteMessage(req *pool.Message, respChan chan struct{}) (
 	return closeFns.ToFunction(), nil
 }
 
-func (cc *Conn) writeMessage(req *pool.Message) error {
-	respChan := make(chan struct{})
+func (cc *Conn) writeMessageAsync(req *pool.Message) error {
 	req.UpsertType(message.Confirmable)
 	req.UpsertMessageID(cc.GetMessageID())
-
-	closeFn, err := cc.prepareWriteMessage(req, respChan)
+	closeFn, err := cc.prepareWriteMessage(req, func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
+		// do nothing
+	})
 	if err != nil {
 		return err
 	}
 	defer closeFn()
-
 	if err := cc.session.WriteMessage(req); err != nil {
 		return fmt.Errorf(errFmtWriteRequest, err)
 	}
-	if req.Type() != message.Confirmable {
-		// If the request is not confirmable, we do not need to wait for a response
-		// and skip retransmissions
-		close(respChan)
-	}
+	return nil
+}
 
-	if err := cc.transmitMessage(req, respChan); err != nil {
+func (cc *Conn) writeMessage(req *pool.Message) error {
+	req.UpsertType(message.Confirmable)
+	req.UpsertMessageID(cc.GetMessageID())
+	if req.Type() != message.Confirmable {
+		return cc.writeMessageAsync(req)
+	}
+	respChan := make(chan struct{})
+	closeFn, err := cc.prepareWriteMessage(req, func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
+		close(respChan)
+	})
+	if err != nil {
+		return err
+	}
+	defer closeFn()
+	if err := cc.session.WriteMessage(req); err != nil {
+		return fmt.Errorf(errFmtWriteRequest, err)
+	}
+	if err := cc.waitForAcknowledge(req, respChan); err != nil {
 		return fmt.Errorf(errFmtWriteRequest, err)
 	}
 	return nil
@@ -375,20 +488,29 @@ func (cc *Conn) Context() context.Context {
 // AsyncPing sends ping and receivedPong will be called when pong arrives. It returns cancellation of ping operation.
 func (cc *Conn) AsyncPing(receivedPong func()) (func(), error) {
 	req := cc.AcquireMessage(cc.Context())
-	defer cc.ReleaseMessage(req)
 	req.SetType(message.Confirmable)
 	req.SetCode(codes.Empty)
 	mid := cc.GetMessageID()
 	req.SetMessageID(mid)
-	if _, loaded := cc.midHandlerContainer.LoadOrStore(mid, func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
-		if r.Type() == message.Reset || r.Type() == message.Acknowledgement {
-			receivedPong()
-		}
+	if _, loaded := cc.midHandlerContainer.LoadOrStore(mid, &midElement{
+		handler: func(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
+			if r.Type() == message.Reset || r.Type() == message.Acknowledgement {
+				receivedPong()
+			}
+		},
+		start:    time.Now(),
+		deadline: time.Time{}, // no deadline
+		private: struct {
+			sync.Mutex
+			msg *pool.Message
+		}{msg: req},
 	}); loaded {
 		return nil, fmt.Errorf("cannot insert mid(%v) handler: %w", mid, coapErrors.ErrKeyAlreadyExists)
 	}
 	removeMidHandler := func() {
-		_, _ = cc.midHandlerContainer.LoadAndDelete(mid)
+		if elem, ok := cc.midHandlerContainer.LoadAndDelete(mid); ok {
+			elem.ReleaseMessage(cc)
+		}
 	}
 	if err := cc.session.WriteMessage(req); err != nil {
 		removeMidHandler()
@@ -415,13 +537,26 @@ func (cc *Conn) LocalAddr() net.Addr {
 	return cc.session.LocalAddr()
 }
 
-func (cc *Conn) sendPong(w *responsewriter.ResponseWriter[*Conn]) {
+func (cc *Conn) sendPong(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
 	if err := w.SetResponse(codes.Empty, message.TextPlain, nil); err != nil {
 		cc.errors(fmt.Errorf("cannot send pong response: %w", err))
 	}
+	if r.Type() == message.Confirmable {
+		w.Message().SetType(message.Acknowledgement)
+		w.Message().SetMessageID(r.MessageID())
+	} else {
+		if w.Message().Type() != message.Reset {
+			w.Message().SetType(message.NonConfirmable)
+		}
+		w.Message().SetMessageID(cc.GetMessageID())
+	}
 }
 
-func (cc *Conn) handleBW(w *responsewriter.ResponseWriter[*Conn], m *pool.Message) {
+func (cc *Conn) handle(w *responsewriter.ResponseWriter[*Conn], m *pool.Message) {
+	if m.IsSeparateMessage() {
+		// msg was processed by token handler - just drop it.
+		return
+	}
 	if cc.blockWise != nil {
 		cc.blockWise.Handle(w, m, cc.blockwiseSZX, cc.session.MaxMessageSize(), func(rw *responsewriter.ResponseWriter[*Conn], rm *pool.Message) {
 			if h, ok := cc.tokenHandlerContainer.LoadAndDelete(rm.Token().Hash()); ok {
@@ -437,22 +572,6 @@ func (cc *Conn) handleBW(w *responsewriter.ResponseWriter[*Conn], m *pool.Messag
 		return
 	}
 	cc.observationHandler.Handle(w, m)
-}
-
-func (cc *Conn) handle(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
-	if r.Code() == codes.Empty && r.Type() == message.Confirmable && len(r.Token()) == 0 && len(r.Options()) == 0 && r.Body() == nil {
-		cc.sendPong(w)
-		return
-	}
-	if h, ok := cc.midHandlerContainer.LoadAndDelete(r.MessageID()); ok {
-		h(w, r)
-		return
-	}
-	if r.IsSeparateMessage() {
-		// msg was processed by token handler - just drop it.
-		return
-	}
-	cc.handleBW(w, r)
 }
 
 // Sequence acquires sequence number.
@@ -612,7 +731,7 @@ func (cc *Conn) closeConnection() {
 	}
 }
 
-func processReqWithHandle(req *pool.Message, cc *Conn, handler config.HandlerFunc[*Conn]) {
+func (cc *Conn) ProcessMessage(req *pool.Message, handler config.HandlerFunc[*Conn]) {
 	defer func() {
 		if !req.IsHijacked() {
 			cc.ReleaseMessage(req)
@@ -634,11 +753,43 @@ func processReqWithHandle(req *pool.Message, cc *Conn, handler config.HandlerFun
 		// nothing to send
 		return
 	}
-	errW := cc.writeMessage(w.Message())
+	errW := cc.writeMessageAsync(w.Message())
 	if errW != nil {
 		cc.closeConnection()
 		cc.errors(fmt.Errorf(errFmtWriteResponse, errW))
 	}
+}
+
+func (cc *Conn) handlePong(w *responsewriter.ResponseWriter[*Conn], r *pool.Message) {
+	cc.sendPong(w, r)
+}
+
+func (cc *Conn) handleSpecialMessages(r *pool.Message) bool {
+	// ping request
+	if r.Code() == codes.Empty && r.Type() == message.Confirmable && len(r.Token()) == 0 && len(r.Options()) == 0 && r.Body() == nil {
+		cc.ProcessMessage(r, cc.handlePong)
+		return true
+	}
+	// it waits for concrete message handler
+	if elem, ok := cc.midHandlerContainer.LoadAndDelete(r.MessageID()); ok {
+		elem.ReleaseMessage(cc)
+		resp := cc.AcquireMessage(cc.Context())
+		resp.SetToken(r.Token())
+		w := responsewriter.New(resp, cc, r.Options()...)
+		defer func() {
+			cc.ReleaseMessage(w.Message())
+		}()
+		elem.handler(w, r)
+		// we just confirmed that message was processed for cc.writeMessage
+		// the body of the message is need to be processed by the loopOverReceivedMessageQueue goroutine
+		return false
+	}
+	// separate message
+	if r.IsSeparateMessage() {
+		// msg was processed by token handler - just drop it.
+		return true
+	}
+	return false
 }
 
 func (cc *Conn) Process(datagram []byte) error {
@@ -654,10 +805,12 @@ func (cc *Conn) Process(datagram []byte) error {
 	req.SetSequence(cc.Sequence())
 	cc.checkMyMessageID(req)
 	cc.inactivityMonitor.Notify()
-	err = cc.goPool(processReqWithHandle, req, cc, cc.handleReq)
-	if err != nil {
-		cc.ReleaseMessage(req)
-		return err
+	if cc.handleSpecialMessages(req) {
+		return nil
+	}
+	select {
+	case cc.receivedMessageQueue <- req:
+	case <-cc.Context().Done():
 	}
 	return nil
 }
@@ -672,6 +825,25 @@ func (cc *Conn) Done() <-chan struct{} {
 	return cc.session.Done()
 }
 
+func (cc *Conn) checkMidHandlerContainer(now time.Time, maxRetransmit int32, acknowledgeTimeout time.Duration, key int32, value *midElement) {
+	if value.IsExpired(now, maxRetransmit) {
+		cc.midHandlerContainer.Delete(key)
+		value.ReleaseMessage(cc)
+		cc.errors(fmt.Errorf(errFmtWriteRequest, context.DeadlineExceeded))
+		return
+	}
+	if !value.Retransmit(now, acknowledgeTimeout) {
+		return
+	}
+	if msg, ok := value.GetMessage(cc); ok {
+		defer cc.ReleaseMessage(msg)
+		err := cc.session.WriteMessage(msg)
+		if err != nil {
+			cc.errors(fmt.Errorf(errFmtWriteRequest, err))
+		}
+	}
+}
+
 // CheckExpirations checks and remove expired items from caches.
 func (cc *Conn) CheckExpirations(now time.Time) {
 	cc.inactivityMonitor.CheckInactivity(now, cc)
@@ -679,6 +851,23 @@ func (cc *Conn) CheckExpirations(now time.Time) {
 	if cc.blockWise != nil {
 		cc.blockWise.CheckExpirations(now)
 	}
+	maxRetransmit := cc.transmission.maxRetransmit.Load()
+	acknowledgeTimeout := cc.transmission.acknowledgeTimeout.Load()
+	x := struct {
+		now                time.Time
+		maxRetransmit      int32
+		acknowledgeTimeout time.Duration
+		cc                 *Conn
+	}{
+		now:                now,
+		maxRetransmit:      maxRetransmit,
+		acknowledgeTimeout: acknowledgeTimeout,
+		cc:                 cc,
+	}
+	cc.midHandlerContainer.Range(func(key int32, value *midElement) bool {
+		x.cc.checkMidHandlerContainer(x.now, x.maxRetransmit, x.acknowledgeTimeout, key, value)
+		return true
+	})
 }
 
 func (cc *Conn) AcquireMessage(ctx context.Context) *pool.Message {

--- a/udp/client/conn_test.go
+++ b/udp/client/conn_test.go
@@ -828,7 +828,7 @@ func TestConnPing(t *testing.T) {
 		require.NoError(t, errC)
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200*1000)
 	defer cancel()
 	err = cc.Ping(ctx)
 	require.NoError(t, err)

--- a/udp/client_test.go
+++ b/udp/client_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -18,7 +19,6 @@ import (
 	coapNet "github.com/plgd-dev/go-coap/v3/net"
 	"github.com/plgd-dev/go-coap/v3/net/responsewriter"
 	"github.com/plgd-dev/go-coap/v3/options"
-	"github.com/plgd-dev/go-coap/v3/options/config"
 	"github.com/plgd-dev/go-coap/v3/pkg/runner/periodic"
 	"github.com/plgd-dev/go-coap/v3/udp/client"
 	"github.com/stretchr/testify/assert"
@@ -742,38 +742,30 @@ func TestClientKeepAliveMonitor(t *testing.T) {
 
 	ld, err := coapNet.NewListenUDP("udp4", "")
 	require.NoError(t, err)
+
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+	defer serverWg.Wait()
 	defer func() {
 		errC := ld.Close()
 		require.NoError(t, errC)
 	}()
-
-	checkClose := semaphore.NewWeighted(2)
-	err = checkClose.Acquire(ctx, 2)
-	require.NoError(t, err)
-	sd := NewServer(
-		options.WithOnNewConn(func(cc *client.Conn) {
-			checkClose.Release(1)
-		}),
-		options.WithGoPool(func(processReqFunc config.ProcessRequestFunc[*client.Conn], req *pool.Message, cc *client.Conn, handler config.HandlerFunc[*client.Conn]) error {
-			time.Sleep(time.Millisecond * 500)
-			processReqFunc(req, cc, handler)
-			return nil
-		}),
-		options.WithPeriodicRunner(periodic.New(ctx.Done(), time.Millisecond*10)),
-	)
-
-	var serverWg sync.WaitGroup
-	defer func() {
-		sd.Stop()
-		serverWg.Wait()
-	}()
-	serverWg.Add(1)
 	go func() {
 		defer serverWg.Done()
-		errS := sd.Serve(ld)
-		require.NoError(t, errS)
+		for {
+			_, _, errR := ld.ReadWithContext(ctx, make([]byte, 1024))
+			if errR != nil {
+				if errors.Is(errR, net.ErrClosed) {
+					return
+				}
+			}
+			require.NoError(t, errR)
+		}
 	}()
 
+	checkClose := semaphore.NewWeighted(1)
+	err = checkClose.Acquire(ctx, 1)
+	require.NoError(t, err)
 	cc, err := Dial(
 		ld.LocalAddr().String(),
 		options.WithKeepAlive(3, 100*time.Millisecond, func(cc *client.Conn) {
@@ -789,13 +781,13 @@ func TestClientKeepAliveMonitor(t *testing.T) {
 		checkClose.Release(1)
 	})
 
-	// send ping to create serverside connection
+	// send ping to create server side connection
 	ctxPing, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
-	err = cc.Ping(ctxPing)
+	_, err = cc.Get(ctxPing, "/tmp")
 	require.Error(t, err)
 
-	err = checkClose.Acquire(ctx, 2)
+	err = checkClose.Acquire(ctx, 1)
 	require.NoError(t, err)
 	require.True(t, inactivityDetected.Load())
 }

--- a/udp/server/config.go
+++ b/udp/server/config.go
@@ -19,8 +19,6 @@ type HandlerFunc = func(*responsewriter.ResponseWriter[*udpClient.Conn], *pool.M
 
 type ErrorFunc = func(error)
 
-type GoPoolFunc = config.GoPoolFunc[*udpClient.Conn]
-
 // OnNewConnFunc is the callback for new connections.
 type OnNewConnFunc = func(cc *udpClient.Conn)
 

--- a/udp/server/server.go
+++ b/udp/server/server.go
@@ -314,11 +314,12 @@ func (s *Server) getOrCreateConn(udpConn *coapNet.UDPConn, raddr *net.UDPAddr) (
 		s.cfg.Handler(w, r)
 	}
 	cfg.BlockwiseSZX = s.cfg.BlockwiseSZX
-	cfg.GoPool = s.cfg.GoPool
 	cfg.Errors = s.cfg.Errors
 	cfg.GetMID = s.cfg.GetMID
 	cfg.GetToken = s.cfg.GetToken
 	cfg.MessagePool = s.cfg.MessagePool
+	cfg.ProcessReceivedMessage = s.cfg.ProcessReceivedMessage
+	cfg.ReceivedMessageQueueSize = s.cfg.ReceivedMessageQueueSize
 
 	cc = client.NewConn(
 		session,


### PR DESCRIPTION
using goPool causes loss of order of messages. For example coap notfications comes in order, but goroutines from gopool are executed underministic.

- WithGoPool was removed
- WithProcessReceivedMessageFunc to modify core cc.ProcessReceivedMessage