### PR TITLE
blockwise transfer: fix race

### DIFF
--- a/message/pool/message.go
+++ b/message/pool/message.go
@@ -575,6 +575,10 @@ func (r *Message) Clone(msg *Message) error {
 		if err != nil {
 			return err
 		}
+		_, err = r.body.Seek(0, io.SeekStart)
+		if err != nil {
+			return err
+		}
 		_, err = io.Copy(buf, r.Body())
 		if err != nil {
 			var errs *multierror.Error

--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -136,7 +136,7 @@ type Client interface {
 type BlockWise[C Client] struct {
 	cc                        C
 	receivingMessagesCache    *cache.Cache[uint64, *messageGuard]
-	sendingMessagesCache      *cache.Cache[uint64, *messageGuard]
+	sendingMessagesCache      *cache.Cache[uint64, *pool.Message]
 	errors                    func(error)
 	getSentRequestFromOutside func(token message.Token) (*pool.Message, bool)
 	expiration                time.Duration
@@ -145,14 +145,12 @@ type BlockWise[C Client] struct {
 type messageGuard struct {
 	*pool.Message
 	*semaphore.Weighted
-	isDoOperation bool
 }
 
-func newRequestGuard(request *pool.Message, isDoOperation bool) *messageGuard {
+func newRequestGuard(request *pool.Message) *messageGuard {
 	return &messageGuard{
-		Message:       request,
-		Weighted:      semaphore.NewWeighted(1),
-		isDoOperation: isDoOperation,
+		Message:  request,
+		Weighted: semaphore.NewWeighted(1),
 	}
 }
 
@@ -170,7 +168,7 @@ func New[C Client](
 	return &BlockWise[C]{
 		cc:                        cc,
 		receivingMessagesCache:    cache.NewCache[uint64, *messageGuard](),
-		sendingMessagesCache:      cache.NewCache[uint64, *messageGuard](),
+		sendingMessagesCache:      cache.NewCache[uint64, *pool.Message](),
 		errors:                    errors,
 		getSentRequestFromOutside: getSentRequestFromOutside,
 		expiration:                expiration,
@@ -216,7 +214,7 @@ func (b *BlockWise[C]) Do(r *pool.Message, maxSzx SZX, maxMessageSize uint32, do
 	if !ok {
 		expire = time.Now().Add(b.expiration)
 	}
-	_, loaded := b.sendingMessagesCache.LoadOrStore(r.Token().Hash(), cache.NewElement(newRequestGuard(r, true), expire, nil))
+	_, loaded := b.sendingMessagesCache.LoadOrStore(r.Token().Hash(), cache.NewElement(r, expire, nil))
 	if loaded {
 		return nil, fmt.Errorf("invalid token")
 	}
@@ -316,7 +314,7 @@ func (b *BlockWise[C]) handleSendingMessage(w *responsewriter.ResponseWriter[C],
 		sizeType = message.Size1
 	}
 
-	szx, num, _, err := DecodeBlockOption(block)
+	szx, num, more, err := DecodeBlockOption(block)
 	if err != nil {
 		return false, fmt.Errorf("cannot decode %v option: %w", blockType, err)
 	}
@@ -359,7 +357,7 @@ func (b *BlockWise[C]) handleSendingMessage(w *responsewriter.ResponseWriter[C],
 
 	buf = buf[:readed]
 	sendMessage.SetBody(bytes.NewReader(buf))
-	more := true
+	more = true
 	if offSeek+int64(readed) == payloadSize {
 		more = false
 	}
@@ -416,7 +414,18 @@ func (b *BlockWise[C]) Handle(w *responsewriter.ResponseWriter[C], r *pool.Messa
 	}
 	tokenStr := token.Hash()
 
-	sendingMessageCached := b.sendingMessagesCache.Load(tokenStr)
+	sendingMessageCached, ok := b.sendingMessagesCache.LoadWithFunc(tokenStr, func(value *cache.Element[*pool.Message]) *cache.Element[*pool.Message] {
+		v := value.Data()
+		msg := b.cc.AcquireMessage(v.Context())
+		err := v.Clone(msg)
+		if err != nil {
+			return nil
+		}
+		return cache.NewElement(msg, value.ValidUntil.Load(), nil)
+	})
+	if ok {
+		defer b.cc.ReleaseMessage(sendingMessageCached.Data())
+	}
 
 	if sendingMessageCached == nil || wantsToBeReceived(r) {
 		err := b.handleReceivedMessage(w, r, maxSZX, maxMessageSize, next)
@@ -473,15 +482,9 @@ func (b *BlockWise[C]) handleReceivedMessage(w *responsewriter.ResponseWriter[C]
 	return b.startSendingMessage(w, maxSZX, maxMessageSize, startSendingMessageBlock)
 }
 
-func (b *BlockWise[C]) continueSendingMessage(w *responsewriter.ResponseWriter[C], r *pool.Message, maxSZX SZX, maxMessageSize uint32, messageGuard *messageGuard) (bool, error) {
-	err := messageGuard.Acquire(r.Context(), 1)
-	if err != nil {
-		return false, fmt.Errorf("cannot lock message: %w", err)
-	}
-	defer messageGuard.Release(1)
-	resp := messageGuard.Message
+func (b *BlockWise[C]) continueSendingMessage(w *responsewriter.ResponseWriter[C], r *pool.Message, maxSZX SZX, maxMessageSize uint32, msg *pool.Message) (bool, error) {
 	blockType := message.Block2
-	switch resp.Code() {
+	switch msg.Code() {
 	case codes.POST, codes.PUT:
 		blockType = message.Block1
 	}
@@ -492,11 +495,11 @@ func (b *BlockWise[C]) continueSendingMessage(w *responsewriter.ResponseWriter[C
 	}
 	if blockType == message.Block1 {
 		// returned blockNumber just acknowledges position we need to set block to the next block.
-		szx, _, more, errB := DecodeBlockOption(block)
+		szx, blockNumber, more, errB := DecodeBlockOption(block)
 		if errB != nil {
 			return false, fmt.Errorf("cannot decode %v(%v) option: %w", blockType, block, errB)
 		}
-		off, errB := resp.Body().Seek(0, io.SeekCurrent)
+		off, errB := msg.Body().Seek((blockNumber+1)*szx.Size(), io.SeekStart)
 		if errB != nil {
 			return false, fmt.Errorf("cannot get current position of seek: %w", errB)
 		}
@@ -506,7 +509,7 @@ func (b *BlockWise[C]) continueSendingMessage(w *responsewriter.ResponseWriter[C
 			return false, fmt.Errorf("cannot encode %v(%v, %v, %v) option: %w", blockType, szx, num, more, errB)
 		}
 	}
-	more, err := b.handleSendingMessage(w, resp, maxSZX, maxMessageSize, r.Token(), block)
+	more, err := b.handleSendingMessage(w, msg, maxSZX, maxMessageSize, r.Token(), block)
 	if err != nil {
 		return false, fmt.Errorf("handleSendingMessage: %w", err)
 	}
@@ -553,7 +556,7 @@ func (b *BlockWise[C]) startSendingMessage(w *responsewriter.ResponseWriter[C], 
 		expire = time.Now().Add(b.expiration)
 	}
 
-	el, loaded := b.sendingMessagesCache.LoadOrStore(sendingMessage.Token().Hash(), cache.NewElement(newRequestGuard(sendingMessage, false), expire, nil))
+	el, loaded := b.sendingMessagesCache.LoadOrStore(sendingMessage.Token().Hash(), cache.NewElement(sendingMessage, expire, nil))
 	if loaded {
 		return fmt.Errorf("cannot add message (%v) to sending message cache: message(%v) with token(%v) already exist", sendingMessage, el.Data(), sendingMessage.Token())
 	}
@@ -561,16 +564,21 @@ func (b *BlockWise[C]) startSendingMessage(w *responsewriter.ResponseWriter[C], 
 }
 
 func (b *BlockWise[C]) getSentRequest(token message.Token) *pool.Message {
-	var req *pool.Message
-	data := b.sendingMessagesCache.Load(token.Hash())
-	if data != nil {
-		v := data.Data()
-		req = b.cc.AcquireMessage(v.Context())
-		req.SetCode(v.Code())
-		req.SetToken(v.Token())
-		req.ResetOptionsTo(v.Options())
-		req.SetType(v.Type())
-		return req
+	data, ok := b.sendingMessagesCache.LoadWithFunc(token.Hash(), func(value *cache.Element[*pool.Message]) *cache.Element[*pool.Message] {
+		if value == nil {
+			return nil
+		}
+		v := value.Data()
+		msg := b.cc.AcquireMessage(v.Context())
+		err := v.Clone(msg)
+		if err != nil {
+			return nil
+		}
+		msg.SetMessageID(-1)
+		return cache.NewElement(msg, value.ValidUntil.Load(), nil)
+	})
+	if ok {
+		return data.Data()
 	}
 	globalRequest, ok := b.getSentRequestFromOutside(token)
 	if ok {
@@ -591,7 +599,7 @@ func (b *BlockWise[C]) handleObserveResponse(sentRequest *pool.Message) (message
 	validUntil := time.Now().Add(b.expiration) // context of observation can be expired.
 	bwSentRequest := b.cloneMessage(sentRequest)
 	bwSentRequest.SetToken(token)
-	_, loaded := b.sendingMessagesCache.LoadOrStore(token.Hash(), cache.NewElement(newRequestGuard(bwSentRequest, false), validUntil, nil))
+	_, loaded := b.sendingMessagesCache.LoadOrStore(token.Hash(), cache.NewElement(bwSentRequest, validUntil, nil))
 	if loaded {
 		return nil, time.Time{}, fmt.Errorf("cannot process message: message with token already exist")
 	}
@@ -699,7 +707,7 @@ func (b *BlockWise[C]) getCachedReceivedMessage(mg *messageGuard, r *pool.Messag
 	msg.SetSequence(r.Sequence())
 	msg.SetBody(memfile.New(make([]byte, 0, 1024)))
 	msg.SetCode(r.Code())
-	mg = newRequestGuard(msg, false)
+	mg = newRequestGuard(msg)
 	errA := mg.Acquire(mg.Context(), 1)
 	if errA != nil {
 		return nil, nil, cannotLockError(errA)

--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -567,11 +567,10 @@ func (b *BlockWise[C]) getSentRequest(token message.Token) *pool.Message {
 		}
 		v := value.Data()
 		msg := b.cc.AcquireMessage(v.Context())
-		err := v.Clone(msg)
-		if err != nil {
-			return nil
-		}
-		msg.SetMessageID(-1)
+		msg.SetCode(v.Code())
+		msg.SetToken(v.Token())
+		msg.ResetOptionsTo(v.Options())
+		msg.SetType(v.Type())
 		return cache.NewElement(msg, value.ValidUntil.Load(), nil)
 	})
 	if ok {

--- a/net/blockwise/blockwise_test.go
+++ b/net/blockwise/blockwise_test.go
@@ -149,7 +149,6 @@ func TestBlockWiseDo(t *testing.T) {
 				payload: memfile.New(make([]byte, 17)),
 			},
 		},
-
 		{
 			name: "SZX16-SZX1024",
 			args: args{

--- a/net/blockwise/blockwise_test.go
+++ b/net/blockwise/blockwise_test.go
@@ -149,6 +149,7 @@ func TestBlockWiseDo(t *testing.T) {
 				payload: memfile.New(make([]byte, 17)),
 			},
 		},
+
 		{
 			name: "SZX16-SZX1024",
 			args: args{
@@ -198,7 +199,7 @@ func TestBlockWiseDo(t *testing.T) {
 				},
 				szx:            SZXBERT,
 				maxMessageSize: SZXBERT.Size() * 2,
-				do: makeDo(t, sender, receiver, SZXBERT, uint32(SZXBERT.Size()*2), SZXBERT, uint32(SZXBERT.Size()*5), func(w *responsewriter.ResponseWriter[*testClient], r *pool.Message) {
+				do: makeDo(t, sender, receiver, SZXBERT, uint32(SZXBERT.Size()*2), SZXBERT, uint32(SZXBERT.Size()*2), func(w *responsewriter.ResponseWriter[*testClient], r *pool.Message) {
 					require.Equal(t, &testmessage{
 						ctx:     context.Background(),
 						token:   []byte{'B', 'E', 'R', 'T'},
@@ -223,6 +224,7 @@ func TestBlockWiseDo(t *testing.T) {
 				payload: memfile.New(make([]byte, 22222)),
 			},
 		},
+
 		{
 			name: "PUT-SZX16-SZX16",
 			args: args{

--- a/net/responsewriter/responseWriter.go
+++ b/net/responsewriter/responseWriter.go
@@ -66,6 +66,13 @@ func (r *ResponseWriter[C]) Message() *pool.Message {
 	return r.response
 }
 
+// Swap message in response without releasing.
+func (r *ResponseWriter[C]) Swap(m *pool.Message) *pool.Message {
+	tmp := r.response
+	r.response = m
+	return tmp
+}
+
 // CConn peer connection.
 func (r *ResponseWriter[C]) Conn() C {
 	return r.cc


### PR DESCRIPTION
Because cached messages are released when "do" operations end and incoming responses are processed simultaneously, a race may occur.

```log
==================
WARNING: DATA RACE
Read at 0x00c000401054 by goroutine 281:
  github.com/plgd-dev/go-coap/v3/message/pool.(*Message).Type()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/message/pool/message.go:109 +0x46
  github.com/plgd-dev/go-coap/v3/net/blockwise.(*BlockWise[...]).getSentRequest()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/blockwise/blockwise.go:572 +0x43c
  github.com/plgd-dev/go-coap/v3/net/blockwise.(*BlockWise[...]).processReceivedMessage()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/blockwise/blockwise.go:756 +0x951
  github.com/plgd-dev/go-coap/v3/net/blockwise.(*BlockWise[...]).handleReceivedMessage()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/blockwise/blockwise.go:468 +0xa90
  github.com/plgd-dev/go-coap/v3/net/blockwise.(*BlockWise[...]).Handle()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/blockwise/blockwise.go:422 +0x7c8
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).handle()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:532 +0x270
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).handleReq()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:690 +0x6e5
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).handleReq-fm()
      <autogenerated>:1 +0x6b
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).ProcessReceivedMessageWithHandler()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:717 +0x4b2
  github.com/plgd-dev/go-coap/v3/udp/client.processReceivedMessage()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:241 +0x5e
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).ProcessReceivedMessage()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:245 +0x10b
  github.com/plgd-dev/go-coap/v3/net/client.(*ReceivedMessageReader[...]).loop()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/client/receivedMessageReader.go:66 +0x39d
  github.com/plgd-dev/go-coap/v3/net/client.(*ReceivedMessageReader[...]).TryToReplaceLoop.func2()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/client/receivedMessageReader.go:95 +0x97

Previous write at 0x00c000401054 by goroutine 8:
  github.com/plgd-dev/go-coap/v3/message/pool.(*Message).SetType()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/message/pool/message.go:96 +0x52
  github.com/plgd-dev/go-coap/v3/message/pool.(*Message).UpsertType()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/message/pool/message.go:105 +0x94
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).writeMessage()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:417 +0x79
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).doInternal()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:284 +0x6bc
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).do.func1()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:313 +0x22d
  github.com/plgd-dev/go-coap/v3/net/blockwise.(*BlockWise[...]).Do()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/blockwise/blockwise.go:225 +0x1f13
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).do()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/udp/client/conn.go:309 +0x237
  github.com/plgd-dev/go-coap/v3/udp/client.(*Conn).do-fm()
      <autogenerated>:1 +0x94
  github.com/plgd-dev/go-coap/v3/net/client/limitParallelRequests.(*LimitParallelRequests).Do()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/client/limitParallelRequests/limitParallelRequests.go:120 +0x98a
  github.com/plgd-dev/go-coap/v3/net/client/limitParallelRequests.(*LimitParallelRequests).Do-fm()
      <autogenerated>:1 +0x94
  github.com/plgd-dev/go-coap/v3/net/observation.(*Observation[...]).Cancel()
      /home/jkralik/go/pkg/mod/github.com/plgd-dev/go-coap/v3@v3.1.0/net/observation/handler.go:219 +0xaa7
  github.com/plgd-dev/go-coap/v3/net/observation.(*Observation[...]).Cancel()
      <autogenerated>:1 +0x91
  github.com/plgd-dev/device/v2/client/core.(*observation).stop()
      /home/jkralik/go/src/github.com/plgd-dev/device/client/core/observeResource.go:142 +0x1c1
  github.com/plgd-dev/device/v2/client/core.(*observation).Stop()
      /home/jkralik/go/src/github.com/plgd-dev/device/client/core/observeResource.go:152 +0x84
  github.com/plgd-dev/device/v2/client/core.(*Device).stopObservingResource()
      /home/jkralik/go/src/github.com/plgd-dev/device/client/core/observeResource.go:72 +0x237
  github.com/plgd-dev/device/v2/client/core.(*Device).StopObservingResource()
      /home/jkralik/go/src/github.com/plgd-dev/device/client/core/observeResource.go:85 +0xee
  github.com/plgd-dev/device/v2/client.(*Client).StopObservingResource()
      /home/jkralik/go/src/github.com/plgd-dev/device/client/observeResource.go:269 +0x5aa
  github.com/plgd-dev/device/v2/client_test.TestClientBUGiotivityLite.func2()
      /home/jkralik/go/src/github.com/plgd-dev/device/client/updateResource_test.go:57 +0xd2
  github.com/plgd-dev/device/v2/client_test.TestClientBUGiotivityLite.func5()
      /home/jkralik/go/src/github.com/plgd-dev/device/client/updateResource_test.go:59 +0x64
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:476 +0x32
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x398
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x5b

Goroutine 281 (running) created at:
```