### PR TITLE
Update observation API

### DIFF
--- a/mux/client.go
+++ b/mux/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Observation = interface {
-	Cancel(ctx context.Context) error
+	Cancel(ctx context.Context, opts ...message.Option) error
 	Canceled() bool
 }
 

--- a/net/client/client.go
+++ b/net/client/client.go
@@ -79,7 +79,7 @@ func (c *Client[C]) Get(ctx context.Context, path string, opts ...message.Option
 }
 
 type Observation = interface {
-	Cancel(ctx context.Context) error
+	Cancel(ctx context.Context, opts ...message.Option) error
 	Canceled() bool
 }
 

--- a/net/client/limitParallelRequests/limitParallelRequests.go
+++ b/net/client/limitParallelRequests/limitParallelRequests.go
@@ -18,7 +18,7 @@ type (
 )
 
 type Observation = interface {
-	Cancel(ctx context.Context) error
+	Cancel(ctx context.Context, opts ...message.Option) error
 	Canceled() bool
 }
 

--- a/net/observation/handler.go
+++ b/net/observation/handler.go
@@ -200,7 +200,7 @@ func (o *Observation[C]) Request() message.Message {
 }
 
 // Cancel remove observation from server. For recreate observation use Observe.
-func (o *Observation[C]) Cancel(ctx context.Context) error {
+func (o *Observation[C]) Cancel(ctx context.Context, opts ...message.Option) error {
 	if !o.cleanUp() {
 		// observation was already cleanup
 		return nil
@@ -208,6 +208,7 @@ func (o *Observation[C]) Cancel(ctx context.Context) error {
 
 	req := o.client().AcquireMessage(ctx)
 	defer o.client().ReleaseMessage(req)
+	req.ResetOptionsTo(opts)
 	req.SetCode(codes.GET)
 	req.SetObserve(1)
 	if path, err := o.req.Options.Path(); err == nil {


### PR DESCRIPTION
Extend observation API to allow setting of CoAP options for the Cancel observation request.