### PR TITLE
net: Enhance observation management with ETag tracking

### DIFF
--- a/net/observation/handler.go
+++ b/net/observation/handler.go
@@ -225,7 +225,7 @@ func (o *Observation[C]) Cancel(ctx context.Context, opts ...message.Option) err
 	}
 	req.SetToken(o.req.Token)
 	etag := o.etag()
-	if etag != nil {
+	if len(etag) > 0 {
 		_ = req.SetETag(etag) // ignore invalid etag
 	}
 	resp, err := o.observationHandler.do(req)
@@ -255,8 +255,11 @@ func (o *Observation[C]) wantBeNotified(r *pool.Message) bool {
 	o.private.obsSequence = obsSequence
 	o.private.lastEvent = now
 	if etag, err := r.ETag(); err == nil {
-		if len(o.private.etag) != len(etag) {
+		if cap(o.private.etag) < len(etag) {
 			o.private.etag = make([]byte, len(etag))
+		}
+		if len(o.private.etag) != len(etag) {
+			o.private.etag = o.private.etag[:len(etag)]
 		}
 		copy(o.private.etag, etag)
 	}

--- a/net/observation/handler.go
+++ b/net/observation/handler.go
@@ -248,14 +248,17 @@ func (o *Observation[C]) wantBeNotified(r *pool.Message) bool {
 
 	o.private.mutex.Lock()
 	defer o.private.mutex.Unlock()
-	if ValidSequenceNumber(o.private.obsSequence, obsSequence, o.private.lastEvent, now) {
-		o.private.obsSequence = obsSequence
-		o.private.lastEvent = now
-		if etag, err := r.ETag(); err == nil {
-			o.private.etag = etag
-		}
-		return true
+	if !ValidSequenceNumber(o.private.obsSequence, obsSequence, o.private.lastEvent, now) {
+		return false
 	}
 
-	return false
+	o.private.obsSequence = obsSequence
+	o.private.lastEvent = now
+	if etag, err := r.ETag(); err == nil {
+		if len(o.private.etag) != len(etag) {
+			o.private.etag = make([]byte, len(etag))
+		}
+		copy(o.private.etag, etag)
+	}
+	return true
 }


### PR DESCRIPTION
This commit introduces an enhancement to the observation mechanism in the network module by implementing ETag tracking. The latest ETag value associated with each observation is now stored in the internal representation.

With this update, each incoming message containing the ETag CoAP option automatically updates the ETag value for the relevant observation. When an observation is canceled, the stored ETag value is utilized. When the server detects a valid ETag match, it now responds with a VALID code and an empty payload instead of resending the content of the resource. This optimization minimizes unnecessary data transfer and reduces network load.