### PR TITLE
Fix processing of observe notifications with ETags

### DIFF
--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -523,10 +523,7 @@ func isObserveResponse(msg *pool.Message) bool {
 	if err != nil {
 		return false
 	}
-	if msg.Code() == codes.Content {
-		return true
-	}
-	return false
+	return msg.Code() >= codes.Created
 }
 
 func (b *BlockWise[C]) startSendingMessage(w *responsewriter.ResponseWriter[C], maxSZX SZX, maxMessageSize uint32, block uint32) error {

--- a/net/observation/handler.go
+++ b/net/observation/handler.go
@@ -91,7 +91,7 @@ func (h *Handler[C]) NewObservation(req *pool.Message, observeFunc func(req *poo
 		err = fmt.Errorf("connection was closed: %w", h.cc.Context().Err())
 		return nil, err
 	case resp := <-respObservationChan:
-		if resp.code != codes.Content {
+		if resp.code != codes.Content && resp.code != codes.Valid {
 			err = fmt.Errorf("unexpected return code(%v)", resp.code)
 			return nil, err
 		}


### PR DESCRIPTION
Upon the commencement of the observation, the client has the ability to include ETAGs options within the GET request utilizing the observe option. Subsequently, on the server side, a Valid status code can be returned if any of the provided ETAGs are found to be a match.