### PR TITLE
Include whitespace between semicolon and encoding

### DIFF
--- a/message/option.go
+++ b/message/option.go
@@ -161,7 +161,7 @@ type MediaType uint16
 
 // Content formats.
 var (
-	TextPlain         MediaType         // text/plain;charset=utf-8
+	TextPlain         MediaType         // text/plain; charset=utf-8
 	AppCoseEncrypt0   MediaType = 16    // application/cose; cose-type="cose-encrypt0" (RFC 8152)
 	AppCoseMac0       MediaType = 17    // application/cose; cose-type="cose-mac0" (RFC 8152)
 	AppCoseSign1      MediaType = 18    // application/cose; cose-type="cose-sign1" (RFC 8152)
@@ -191,7 +191,7 @@ var (
 )
 
 var mediaTypeToString = map[MediaType]string{
-	TextPlain:         "text/plain;charset=utf-8",
+	TextPlain:         "text/plain; charset=utf-8",
 	AppCoseEncrypt0:   "application/cose; cose-type=\"cose-encrypt0\" (RFC 8152)",
 	AppCoseMac0:       "application/cose; cose-type=\"cose-mac0\" (RFC 8152)",
 	AppCoseSign1:      "application/cose; cose-type=\"cose-sign1\" (RFC 8152)",


### PR DESCRIPTION
Updates the text/plain media type string to use a space between the semicolon and the encoding. While this is not strictly required, it more closely aligns with the media types in the content format registry.

https://www.iana.org/assignments/core-parameters/core-parameters.xhtml