### PR TITLE
fix: do not attempt serve DTLS connection on accept error

### DIFF
--- a/dtls/server/server.go
+++ b/dtls/server/server.go
@@ -153,7 +153,7 @@ func (s *Server) Serve(l Listener) error {
 		if ok := s.checkAcceptError(err); !ok {
 			return nil
 		}
-		if rw == nil {
+		if err != nil || rw == nil {
 			continue
 		}
 		wg.Add(1)


### PR DESCRIPTION
Updates the DTLS server to skip serving a DTLS connection when an error is returned. Previously, if an error was returned that did not meet the criteria of shutting down the server altogether, a non-nil DTLS connection would still attempt to be served. This can cause a panic if the net.Conn interface is non-nil, but the underlying value is.

Fixes #488 