### PR TITLE
Interface must be UP and RUNNING for testing

### DIFF
--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -91,7 +91,7 @@ func TestServerDiscover(t *testing.T) {
 	log.Printf("ifs:%v", ifs)
 	var iface net.Interface
 	for _, i := range ifs {
-		if i.Flags&net.FlagMulticast == net.FlagMulticast && i.Flags&net.FlagUp == net.FlagUp && i.Flags&net.FlagRunning == net.FlagRunning{
+		if i.Flags&net.FlagMulticast == net.FlagMulticast && i.Flags&net.FlagUp == net.FlagUp && i.Flags&net.FlagRunning == net.FlagRunning {
 			iface = i
 			log.Printf("first available multicast if:%v", iface)
 			break

--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -91,7 +91,7 @@ func TestServerDiscover(t *testing.T) {
 	log.Printf("ifs:%v", ifs)
 	var iface net.Interface
 	for _, i := range ifs {
-		if i.Flags&net.FlagMulticast == net.FlagMulticast && i.Flags&net.FlagUp == net.FlagUp {
+		if i.Flags&net.FlagMulticast == net.FlagMulticast && i.Flags&net.FlagUp == net.FlagUp && i.Flags&net.FlagRunning == net.FlagRunning{
 			iface = i
 			log.Printf("first available multicast if:%v", iface)
 			break


### PR DESCRIPTION
Interfaces must be up and running to be able to transport even loopback multicast. Without this one (or more) of the TestServerDiscovery tests might fail.

`
go test ./...

...

2023/10/17 11:41:55 ifs:[{1 65536 lo  up|loopback|running} {2 1500 enp1s0f0 ...

2023/10/17 11:41:55 first available multicast if:{2 1500 enp1s0f0 xx:xx:xx:xx:xx:xx  up|broadcast|multicast}
--- FAIL: TestServerDiscover (1.50s)
    --- FAIL: TestServerDiscover/valid_first_interface (0.50s)
        server_test.go:199: 
                Error Trace:    /home/henning.rogge/develop/fkie-apps/go-coap/udp/server_test.go:199
                Error:          "0" is not greater than "0"
                Test:           TestServerDiscover/valid_first_interface
2023/10/17 11:42:04 inactivityMonitor
2023/10/17 11:42:04 inactivityMonitor
FAIL
FAIL    github.com/plgd-dev/go-coap/v3/udp      12.271s
ok      github.com/plgd-dev/go-coap/v3/udp/client       (cached)
ok      github.com/plgd-dev/go-coap/v3/udp/coder        (cached)
FAIL
henning.rogge$ ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: enp1s0f0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel state DOWN mode DEFAULT group default qlen 1000
    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
`