### PR TITLE
Incoming interface

### DIFF
--- a/message/pool/message.go
+++ b/message/pool/message.go
@@ -32,6 +32,7 @@ type Message struct {
 	origValueBuffer []byte
 	body            io.ReadSeeker
 	sequence        uint64
+	ifIndex         int
 
 	// local vars
 	bufferUnmarshal []byte
@@ -423,6 +424,14 @@ func (r *Message) SetSequence(seq uint64) {
 
 func (r *Message) Sequence() uint64 {
 	return r.sequence
+}
+
+func (r *Message) SetIfIndex(ifIndex int) {
+	r.ifIndex = ifIndex
+}
+
+func (r *Message) IfIndex() int {
+	return r.ifIndex
 }
 
 func (r *Message) Hijack() {

--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -29,7 +29,7 @@ type ControlMessage struct {
 }
 
 type UDPSrc struct {
-	Addr net.UDPAddr
+	Addr    net.UDPAddr
 	IfIndex int
 }
 
@@ -165,7 +165,7 @@ var DefaultUDPConnConfig = UDPConnConfig{
 }
 
 type UDPConnConfig struct {
-	Errors    func(err error)
+	Errors func(err error)
 }
 
 func NewListenUDP(network, addr string, opts ...UDPOption) (*UDPConn, error) {
@@ -475,7 +475,7 @@ func (c *UDPConn) ReadWithContext(ctx context.Context, buffer []byte) (int, *net
 	if err != nil {
 		return -1, nil, fmt.Errorf("cannot read from udp connection: %w", err)
 	}
-	return n,s,nil
+	return n, s, nil
 }
 
 // ReadWithContext reads packet with context. In addition to the length in bytes and the remote address, it also

--- a/udp/client/conn.go
+++ b/udp/client/conn.go
@@ -772,6 +772,7 @@ func (cc *Conn) handleSpecialMessages(r *pool.Message) bool {
 func (cc *Conn) Process(datagram []byte) error {
 	return cc.ProcessWithIf(datagram, 0)
 }
+
 func (cc *Conn) ProcessWithIf(datagram []byte, ifIndex int) error {
 	if uint32(len(datagram)) > cc.session.MaxMessageSize() {
 		return fmt.Errorf("max message size(%v) was exceeded %v", cc.session.MaxMessageSize(), len(datagram))

--- a/udp/client/conn.go
+++ b/udp/client/conn.go
@@ -770,6 +770,9 @@ func (cc *Conn) handleSpecialMessages(r *pool.Message) bool {
 }
 
 func (cc *Conn) Process(datagram []byte) error {
+	return cc.ProcessWithIf(datagram, 0)
+}
+func (cc *Conn) ProcessWithIf(datagram []byte, ifIndex int) error {
 	if uint32(len(datagram)) > cc.session.MaxMessageSize() {
 		return fmt.Errorf("max message size(%v) was exceeded %v", cc.session.MaxMessageSize(), len(datagram))
 	}
@@ -780,6 +783,7 @@ func (cc *Conn) Process(datagram []byte) error {
 		return err
 	}
 	req.SetSequence(cc.Sequence())
+	req.SetIfIndex(ifIndex)
 	cc.checkMyMessageID(req)
 	cc.inactivityMonitor.Notify()
 	if cc.handleSpecialMessages(req) {

--- a/udp/server/server.go
+++ b/udp/server/server.go
@@ -255,7 +255,7 @@ func getClose(cc *client.Conn) func() {
 	return closeFn
 }
 
-func cleanupRAddr(raddr *net.UDPAddr) *net.UDPAddr{
+func cleanupRAddr(raddr *net.UDPAddr) *net.UDPAddr {
 	if raddr.IP.To4() == nil && (raddr.IP.IsLinkLocalMulticast() || raddr.IP.IsLinkLocalUnicast() || raddr.IP.IsInterfaceLocalMulticast()) {
 		return raddr
 	}


### PR DESCRIPTION
When building lowlevel network services with multiple interfaces, its often useful or even necessary to know the specific interface from which a Message was received from. This change uses the already existing packagecon in connUDP to get the interface from the operation system and stores it in the Message.