### PR TITLE
Improve mux errors

### DIFF
--- a/mux/router.go
+++ b/mux/router.go
@@ -81,6 +81,13 @@ func NewRouter() *Router {
 	return router
 }
 
+// SetErrorHandler sets a custom error handler for the default mux handler set in the constructor.
+func (r *Router) SetErrorHandler(h func(error)) {
+	r.m.Lock()
+	defer r.m.Unlock()
+	r.errors = h
+}
+
 // Does path match pattern?
 func pathMatch(pattern Route, path string) bool {
 	return pattern.regexMatcher.regexp.MatchString(path)

--- a/mux/router.go
+++ b/mux/router.go
@@ -155,6 +155,8 @@ func (r *Router) DefaultHandle(handler Handler) {
 }
 
 // HandleFunc adds a handler function to the Router for pattern.
+// This function will panic if the pattern parameter is invalid. If the APP provides 'user defined patterns' better
+// use Handle(), which will return an error.
 func (r *Router) HandleFunc(pattern string, handler func(w ResponseWriter, r *Message)) {
 	if err := r.Handle(pattern, HandlerFunc(handler)); err != nil {
 		panic(fmt.Errorf("cannot handle pattern(%v): %w", pattern, err))

--- a/mux/router.go
+++ b/mux/router.go
@@ -150,7 +150,7 @@ func (r *Router) DefaultHandle(handler Handler) {
 // HandleFunc adds a handler function to the Router for pattern.
 func (r *Router) HandleFunc(pattern string, handler func(w ResponseWriter, r *Message)) {
 	if err := r.Handle(pattern, HandlerFunc(handler)); err != nil {
-		r.errors(fmt.Errorf("cannot handle pattern(%v): %w", pattern, err))
+		panic(fmt.Errorf("cannot handle pattern(%v): %w", pattern, err))
 	}
 }
 


### PR DESCRIPTION
The user should be able to use its own error handler for the mux router. In addition to this the mux should not silently log an error if the API user provides a bad path pattern.