### PR TITLE
mux: filter for invalid root path pattern

### DIFF
--- a/mux/router_test.go
+++ b/mux/router_test.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/plgd-dev/go-coap/v3/mux"
 	"github.com/stretchr/testify/require"
+
+	// TODO: replace with standard maps package as soon as Go dependency hits 1.20
+	"golang.org/x/exp/maps"
 )
 
 type routeTest struct {
@@ -144,7 +147,7 @@ func testRoute(t *testing.T, router *mux.Router, test routeTest) {
 		t.Errorf("(%v) %v:\nPath: %#v\nPathTemplate: %#v\nVars: %v\n", test.title, msg, test.path, test.pathTemplate, test.vars)
 	}
 	if test.shouldMatch {
-		if vars != nil && !stringMapEqual(vars, routeParams.Vars) {
+		if vars != nil && !maps.Equal(vars, routeParams.Vars) {
 			t.Errorf("(%v) Vars not equal: expected %v, got %v", test.title, vars, routeParams.Vars)
 			return
 		}
@@ -154,19 +157,4 @@ func testRoute(t *testing.T, router *mux.Router, test routeTest) {
 			return
 		}
 	}
-}
-
-// stringMapEqual checks the equality of two string maps
-func stringMapEqual(m1, m2 map[string]string) bool {
-	nil1 := len(m1) == 0
-	nil2 := len(m2) == 0
-	if nil1 != nil2 || len(m1) != len(m2) {
-		return false
-	}
-	for k, v := range m1 {
-		if v != m2[k] {
-			return false
-		}
-	}
-	return true
 }

--- a/mux/router_test.go
+++ b/mux/router_test.go
@@ -158,8 +158,8 @@ func testRoute(t *testing.T, router *mux.Router, test routeTest) {
 
 // stringMapEqual checks the equality of two string maps
 func stringMapEqual(m1, m2 map[string]string) bool {
-	nil1 := m1 == nil || len(m1) == 0
-	nil2 := m2 == nil || len(m2) == 0
+	nil1 := len(m1) == 0
+	nil2 := len(m2) == 0
 	if nil1 != nil2 || len(m1) != len(m2) {
 		return false
 	}

--- a/mux/router_test.go
+++ b/mux/router_test.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/plgd-dev/go-coap/v3/mux"
 	"github.com/stretchr/testify/require"
-
-	// TODO: replace with standard maps package as soon as Go dependency hits 1.20
-	"golang.org/x/exp/maps"
+	"golang.org/x/exp/maps" // TODO: replace with standard maps package as soon as Go dependency hits 1.20
 )
 
 type routeTest struct {

--- a/mux/router_test.go
+++ b/mux/router_test.go
@@ -78,6 +78,34 @@ func TestMux(t *testing.T) {
 			pathTemplate: `/{category:a|b/c}`,
 			shouldMatch:  true,
 		},
+		{
+			title:        "root path without slash",
+			vars:         map[string]string{},
+			path:         "",
+			pathTemplate: "",
+			shouldMatch:  true,
+		},
+		{
+			title:        "root path with slash",
+			vars:         map[string]string{},
+			path:         "/",
+			pathTemplate: "/",
+			shouldMatch:  true,
+		},
+		{
+			title:        "root path without slash",
+			vars:         map[string]string{},
+			path:         "",
+			pathTemplate: "/",
+			shouldMatch:  true,
+		},
+		{
+			title:        "root path with slash",
+			vars:         map[string]string{},
+			path:         "/",
+			pathTemplate: "",
+			shouldMatch:  true,
+		},
 	}
 
 	for _, test := range tests {
@@ -121,8 +149,8 @@ func testRoute(t *testing.T, router *mux.Router, test routeTest) {
 			return
 		}
 
-		if routeParams.PathTemplate != test.pathTemplate {
-			t.Errorf("(%v) PathTemplate not equal: expected %v, got %v", test.title, test.pathTemplate, test.pathTemplate)
+		if routeParams.PathTemplate != mux.FilterPath(test.pathTemplate) {
+			t.Errorf("(%v) PathTemplate not equal: expected %v, got %v", test.title, test.pathTemplate, routeParams.PathTemplate)
 			return
 		}
 	}
@@ -130,8 +158,8 @@ func testRoute(t *testing.T, router *mux.Router, test routeTest) {
 
 // stringMapEqual checks the equality of two string maps
 func stringMapEqual(m1, m2 map[string]string) bool {
-	nil1 := m1 == nil
-	nil2 := m2 == nil
+	nil1 := m1 == nil || len(m1) == 0
+	nil2 := m2 == nil || len(m2) == 0
 	if nil1 != nil2 || len(m1) != len(m2) {
 		return false
 	}


### PR DESCRIPTION
Mux router has trouble with root path matching because of the different semantics of empty path and "/" path. Add the already existing filter into all relevant router functions and add extend test cases to check all combinations.