### PR TITLE
mux: Root path handling improvement

### DIFF
--- a/mux/router.go
+++ b/mux/router.go
@@ -215,7 +215,7 @@ func (r *Router) ServeCOAP(w ResponseWriter, req *Message) {
 	r.m.RLock()
 	defaultHandler := r.defaultHandler
 	r.m.RUnlock()
-	if err != nil {
+	if err != nil && !errors.Is(err, message.ErrOptionNotFound) {
 		defaultHandler.ServeCOAP(w, req)
 		return
 	}


### PR DESCRIPTION
This modification ensures that the mux treats both "/" and an empty path ("") as requests to the root path. The reason behind this is the absence of the Uri-path option in CoAP requests in such instances.

Fixes #446 