### PR TITLE
Add Request Monitoring Feature to CoAP Connection

### DIFF
--- a/dtls/client.go
+++ b/dtls/client.go
@@ -105,10 +105,11 @@ func Client(conn *dtls.Conn, opts ...udp.Option) *udpClient.Conn {
 		cfg.MTU,
 		cfg.CloseSocket,
 	)
-	cc := udpClient.NewConn(session,
-		createBlockWise,
-		monitor,
+	cc := udpClient.NewConnWithOpts(session,
 		&cfg,
+		udpClient.WithBlockWise(createBlockWise),
+		udpClient.WithInactivityMonitor(monitor),
+		udpClient.WithRequestMonitor(cfg.RequestMonitor),
 	)
 
 	cfg.PeriodicRunner(func(now time.Time) bool {

--- a/dtls/server/config.go
+++ b/dtls/server/config.go
@@ -22,9 +22,6 @@ type ErrorFunc = func(error)
 // OnNewConnFunc is the callback for new connections.
 type OnNewConnFunc = func(cc *udpClient.Conn)
 
-// RequestMonitorFunc is the callback to see any requests.
-type RequestMonitorFunc = func(cc *udpClient.Conn, req *pool.Message)
-
 type GetMIDFunc = func() int32
 
 var DefaultConfig = func() Config {
@@ -37,8 +34,8 @@ var DefaultConfig = func() Config {
 			}
 			return inactivity.New(timeout, onInactive)
 		},
-		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) {
-			// do nothing by default
+		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) error {
+			return nil
 		},
 		OnNewConn: func(cc *udpClient.Conn) {
 			// do nothing by default
@@ -63,7 +60,7 @@ type Config struct {
 	GetMID                         GetMIDFunc
 	Handler                        HandlerFunc
 	OnNewConn                      OnNewConnFunc
-	RequestMonitor                 RequestMonitorFunc
+	RequestMonitor                 udpClient.RequestMonitorFunc
 	TransmissionNStart             uint32
 	TransmissionAcknowledgeTimeout time.Duration
 	TransmissionMaxRetransmit      uint32

--- a/dtls/server/config.go
+++ b/dtls/server/config.go
@@ -22,6 +22,9 @@ type ErrorFunc = func(error)
 // OnNewConnFunc is the callback for new connections.
 type OnNewConnFunc = func(cc *udpClient.Conn)
 
+// RequestMonitorFunc is the callback to see any requests.
+type RequestMonitorFunc = func(cc *udpClient.Conn, req *pool.Message)
+
 type GetMIDFunc = func() int32
 
 var DefaultConfig = func() Config {
@@ -33,6 +36,9 @@ var DefaultConfig = func() Config {
 				_ = cc.Close()
 			}
 			return inactivity.New(timeout, onInactive)
+		},
+		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) {
+			// do nothing by default
 		},
 		OnNewConn: func(cc *udpClient.Conn) {
 			// do nothing by default
@@ -57,6 +63,7 @@ type Config struct {
 	GetMID                         GetMIDFunc
 	Handler                        HandlerFunc
 	OnNewConn                      OnNewConnFunc
+	RequestMonitor                 RequestMonitorFunc
 	TransmissionNStart             uint32
 	TransmissionAcknowledgeTimeout time.Duration
 	TransmissionMaxRetransmit      uint32

--- a/dtls/server/config.go
+++ b/dtls/server/config.go
@@ -34,8 +34,8 @@ var DefaultConfig = func() Config {
 			}
 			return inactivity.New(timeout, onInactive)
 		},
-		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) error {
-			return nil
+		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) (bool, error) {
+			return false, nil
 		},
 		OnNewConn: func(cc *udpClient.Conn) {
 			// do nothing by default

--- a/dtls/server/server.go
+++ b/dtls/server/server.go
@@ -224,12 +224,12 @@ func (s *Server) createConn(connection *coapNet.Conn, inactivityMonitor udpClien
 	cfg.ReceivedMessageQueueSize = s.cfg.ReceivedMessageQueueSize
 	cfg.ProcessReceivedMessage = s.cfg.ProcessReceivedMessage
 
-	cc := udpClient.NewConn(
+	cc := udpClient.NewConnWithOpts(
 		session,
-		createBlockWise,
-		inactivityMonitor,
-		requestMonitor,
 		&cfg,
+		udpClient.WithBlockWise(createBlockWise),
+		udpClient.WithInactivityMonitor(inactivityMonitor),
+		udpClient.WithRequestMonitor(requestMonitor),
 	)
 
 	return cc

--- a/message/message.go
+++ b/message/message.go
@@ -48,3 +48,11 @@ func (r *Message) String() string {
 	}
 	return buf
 }
+
+// IsPing returns true if the message is a ping.
+func (r *Message) IsPing(isTCP bool) bool {
+	if isTCP {
+		return r.Code == codes.Ping
+	}
+	return r.Code == codes.Empty && r.Type == Confirmable && len(r.Token) == 0 && len(r.Options) == 0 && len(r.Payload) == 0
+}

--- a/message/message_internal_test.go
+++ b/message/message_internal_test.go
@@ -1,0 +1,73 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/plgd-dev/go-coap/v3/message/codes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageIsPing(t *testing.T) {
+	tests := []struct {
+		name    string
+		message *Message
+		isTCP   bool
+		want    bool
+	}{
+		{
+			name: "Ping message (TCP)",
+			message: &Message{
+				Code:    codes.Ping,
+				Type:    Confirmable,
+				Token:   nil,
+				Options: nil,
+				Payload: nil,
+			},
+			isTCP: true,
+			want:  true,
+		},
+		{
+			name: "Ping message (UDP)",
+			message: &Message{
+				Code:    codes.Empty,
+				Type:    Confirmable,
+				Token:   nil,
+				Options: nil,
+				Payload: nil,
+			},
+			isTCP: false,
+			want:  true,
+		},
+		{
+			name: "Non-ping message (TCP)",
+			message: &Message{
+				Code:    codes.GET,
+				Type:    Confirmable,
+				Token:   []byte{1, 2, 3},
+				Options: []Option{{ID: 1, Value: []byte{4, 5, 6}}},
+				Payload: []byte{7, 8, 9},
+			},
+			isTCP: true,
+			want:  false,
+		},
+		{
+			name: "Non-ping message (UDP)",
+			message: &Message{
+				Code:    codes.GET,
+				Type:    Confirmable,
+				Token:   []byte{1, 2, 3},
+				Options: []Option{{ID: 1, Value: []byte{4, 5, 6}}},
+				Payload: []byte{7, 8, 9},
+			},
+			isTCP: false,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.message.IsPing(tt.isTCP)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/message/pool/message.go
+++ b/message/pool/message.go
@@ -618,3 +618,7 @@ func (r *Message) Clone(msg *Message) error {
 	}
 	return nil
 }
+
+func (r *Message) IsPing(isTCP bool) bool {
+	return r.msg.IsPing(isTCP)
+}

--- a/options/commonOptions.go
+++ b/options/commonOptions.go
@@ -595,7 +595,7 @@ func WithOnNewConn[F OnNewConnFunc](onNewConn F) OnNewConnOpt[F] {
 
 // WithRequestMonitor
 type WithRequestMonitorFunc interface {
-	tcpServer.RequestMonitorFunc | udpServer.RequestMonitorFunc
+	tcpClient.RequestMonitorFunc | udpClient.RequestMonitorFunc
 }
 
 // WithRequestMonitorOpt network option.
@@ -609,30 +609,30 @@ func panicForInvalidWithRequestMonitorFunc(t, exp any) {
 
 func (o WithRequestMonitorOpt[F]) UDPServerApply(cfg *udpServer.Config) {
 	switch v := any(o.f).(type) {
-	case udpServer.RequestMonitorFunc:
+	case udpClient.RequestMonitorFunc:
 		cfg.RequestMonitor = v
 	default:
-		var exp udpServer.RequestMonitorFunc
+		var exp udpClient.RequestMonitorFunc
 		panicForInvalidWithRequestMonitorFunc(v, exp)
 	}
 }
 
 func (o WithRequestMonitorOpt[F]) DTLSServerApply(cfg *dtlsServer.Config) {
 	switch v := any(o.f).(type) {
-	case udpServer.RequestMonitorFunc:
+	case udpClient.RequestMonitorFunc:
 		cfg.RequestMonitor = v
 	default:
-		var exp udpServer.RequestMonitorFunc
+		var exp udpClient.RequestMonitorFunc
 		panicForInvalidWithRequestMonitorFunc(v, exp)
 	}
 }
 
 func (o WithRequestMonitorOpt[F]) TCPServerApply(cfg *tcpServer.Config) {
 	switch v := any(o.f).(type) {
-	case tcpServer.RequestMonitorFunc:
+	case tcpClient.RequestMonitorFunc:
 		cfg.RequestMonitor = v
 	default:
-		var exp tcpServer.RequestMonitorFunc
+		var exp tcpClient.RequestMonitorFunc
 		panicForInvalidWithRequestMonitorFunc(v, exp)
 	}
 }

--- a/options/commonOptions.go
+++ b/options/commonOptions.go
@@ -637,7 +637,10 @@ func (o WithRequestMonitorOpt[F]) TCPServerApply(cfg *tcpServer.Config) {
 	}
 }
 
-// WithRequestMonitor ping handler
+// WithRequestMonitor enables request monitoring for the connection.
+// It is called for each CoAP message received from the peer before it is processed.
+// If it returns an error, the connection is closed.
+// If it returns true, the message is dropped.
 func WithRequestMonitor[F WithRequestMonitorFunc](requestMonitor F) WithRequestMonitorOpt[F] {
 	return WithRequestMonitorOpt[F]{
 		f: requestMonitor,

--- a/options/commonOptions.go
+++ b/options/commonOptions.go
@@ -593,6 +593,57 @@ func WithOnNewConn[F OnNewConnFunc](onNewConn F) OnNewConnOpt[F] {
 	}
 }
 
+// WithRequestMonitor
+type WithRequestMonitorFunc interface {
+	tcpServer.RequestMonitorFunc | udpServer.RequestMonitorFunc
+}
+
+// WithRequestMonitorOpt network option.
+type WithRequestMonitorOpt[F WithRequestMonitorFunc] struct {
+	f F
+}
+
+func panicForInvalidWithRequestMonitorFunc(t, exp any) {
+	panic(fmt.Errorf("invalid WithRequestMonitorFunc type %T, expected %T", t, exp))
+}
+
+func (o WithRequestMonitorOpt[F]) UDPServerApply(cfg *udpServer.Config) {
+	switch v := any(o.f).(type) {
+	case udpServer.RequestMonitorFunc:
+		cfg.RequestMonitor = v
+	default:
+		var exp udpServer.RequestMonitorFunc
+		panicForInvalidWithRequestMonitorFunc(v, exp)
+	}
+}
+
+func (o WithRequestMonitorOpt[F]) DTLSServerApply(cfg *dtlsServer.Config) {
+	switch v := any(o.f).(type) {
+	case udpServer.RequestMonitorFunc:
+		cfg.RequestMonitor = v
+	default:
+		var exp udpServer.RequestMonitorFunc
+		panicForInvalidWithRequestMonitorFunc(v, exp)
+	}
+}
+
+func (o WithRequestMonitorOpt[F]) TCPServerApply(cfg *tcpServer.Config) {
+	switch v := any(o.f).(type) {
+	case tcpServer.RequestMonitorFunc:
+		cfg.RequestMonitor = v
+	default:
+		var exp tcpServer.RequestMonitorFunc
+		panicForInvalidWithRequestMonitorFunc(v, exp)
+	}
+}
+
+// WithRequestMonitor ping handler
+func WithRequestMonitor[F WithRequestMonitorFunc](requestMonitor F) WithRequestMonitorOpt[F] {
+	return WithRequestMonitorOpt[F]{
+		f: requestMonitor,
+	}
+}
+
 // CloseSocketOpt close socket option.
 type CloseSocketOpt struct{}
 

--- a/tcp/client.go
+++ b/tcp/client.go
@@ -88,10 +88,11 @@ func Client(conn net.Conn, opts ...Option) *client.Conn {
 
 	l := coapNet.NewConn(conn)
 	monitor := cfg.CreateInactivityMonitor()
-	cc := client.NewConn(l,
-		createBlockWise,
-		monitor,
+	cc := client.NewConnWithOpts(l,
 		&cfg,
+		client.WithBlockWise(createBlockWise),
+		client.WithInactivityMonitor(monitor),
+		client.WithRequestMonitor(cfg.RequestMonitor),
 	)
 
 	cfg.PeriodicRunner(func(now time.Time) bool {

--- a/tcp/client/config.go
+++ b/tcp/client/config.go
@@ -20,6 +20,9 @@ var DefaultConfig = func() Config {
 		CreateInactivityMonitor: func() InactivityMonitor {
 			return inactivity.NewNilMonitor[*Conn]()
 		},
+		RequestMonitor: func(*Conn, *pool.Message) error {
+			return nil
+		},
 		Dialer:              &net.Dialer{Timeout: time.Second * 3},
 		Net:                 "tcp",
 		ConnectionCacheSize: 2048,
@@ -38,6 +41,7 @@ var DefaultConfig = func() Config {
 type Config struct {
 	config.Common[*Conn]
 	CreateInactivityMonitor         CreateInactivityMonitorFunc
+	RequestMonitor                  RequestMonitorFunc
 	Net                             string
 	Dialer                          *net.Dialer
 	TLSCfg                          *tls.Config

--- a/tcp/client/config.go
+++ b/tcp/client/config.go
@@ -20,8 +20,8 @@ var DefaultConfig = func() Config {
 		CreateInactivityMonitor: func() InactivityMonitor {
 			return inactivity.NewNilMonitor[*Conn]()
 		},
-		RequestMonitor: func(*Conn, *pool.Message) error {
-			return nil
+		RequestMonitor: func(*Conn, *pool.Message) (bool, error) {
+			return false, nil
 		},
 		Dialer:              &net.Dialer{Timeout: time.Second * 3},
 		Net:                 "tcp",

--- a/tcp/client/conn.go
+++ b/tcp/client/conn.go
@@ -384,7 +384,6 @@ func (cc *Conn) handleSignals(r *pool.Message) bool {
 		// if r.HasOption(message.TCPCustody) {
 		// TODO
 		// }
-		cc.session.requestMonitor(cc, r)
 		if err := cc.sendPong(r.Token()); err != nil && !coapNet.IsConnectionBrokenError(err) {
 			cc.Session().errors(fmt.Errorf("cannot handle ping signal: %w", err))
 		}

--- a/tcp/client/session.go
+++ b/tcp/client/session.go
@@ -23,6 +23,7 @@ type Session struct {
 	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	sequence          atomic.Uint64
 	inactivityMonitor InactivityMonitor
+	requestMonitor    RequestMonitorFunc
 	errSendCSM        error
 	cancel            context.CancelFunc
 	done              chan struct{}
@@ -48,6 +49,7 @@ func NewSession(
 	disableTCPSignalMessageCSM bool,
 	closeSocket bool,
 	inactivityMonitor InactivityMonitor,
+	requestMonitor RequestMonitorFunc,
 	connectionCacheSize uint16,
 	messagePool *pool.Pool,
 ) *Session {
@@ -69,6 +71,7 @@ func NewSession(
 		disableTCPSignalMessageCSM: disableTCPSignalMessageCSM,
 		closeSocket:                closeSocket,
 		inactivityMonitor:          inactivityMonitor,
+		requestMonitor:             requestMonitor,
 		done:                       make(chan struct{}),
 		connectionCacheSize:        connectionCacheSize,
 		messagePool:                messagePool,

--- a/tcp/client_test.go
+++ b/tcp/client_test.go
@@ -3,6 +3,7 @@ package tcp
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"sync"
 	"testing"
@@ -666,4 +667,93 @@ func TestClientKeepAliveMonitor(t *testing.T) {
 	err = checkClose.Acquire(ctx, 2)
 	require.NoError(t, err)
 	require.True(t, inactivityDetected.Load())
+}
+
+func TestConnRequestMonitor(t *testing.T) {
+	l, err := coapNet.NewTCPListener("tcp", "")
+	require.NoError(t, err)
+	defer func() {
+		errC := l.Close()
+		require.NoError(t, errC)
+	}()
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	m := mux.NewRouter()
+
+	// The response counts up with every get
+	// so we can check if the handler is only called once per message ID
+	err = m.Handle("/test", mux.HandlerFunc(func(w mux.ResponseWriter, r *mux.Message) {
+		errH := w.SetResponse(codes.Content, message.TextPlain, nil)
+		require.NoError(t, errH)
+	}))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+	closeConn := make(chan struct{}, 1)
+	var isEOF atomic.Bool
+	testEOFError := errors.New("test error")
+	s := NewServer(
+		options.WithMux(m),
+		options.WithRequestMonitor(func(c *client.Conn, req *pool.Message) error {
+			if req.Code() == codes.DELETE {
+				return testEOFError
+			}
+			return nil
+		}),
+		options.WithErrors(func(err error) {
+			t.Log(err)
+			if errors.Is(err, testEOFError) {
+				isEOF.Store(true)
+			}
+		}),
+		options.WithOnNewConn(func(c *client.Conn) {
+			t.Log("new conn")
+			c.AddOnClose(func() {
+				t.Log("close conn")
+				select {
+				case closeConn <- struct{}{}:
+					cancel()
+				default:
+				}
+			})
+		}))
+	defer s.Stop()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errS := s.Serve(l)
+		require.NoError(t, errS)
+	}()
+
+	cc, err := Dial(l.Addr().String(),
+		options.WithErrors(func(err error) {
+			t.Log(err)
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		errC := cc.Close()
+		require.NoError(t, errC)
+	}()
+
+	// Setup done - Run Tests
+	// Same request, executed twice (needs the same token)
+	getReq, err := cc.NewGetRequest(ctx, "/test")
+	getReq.SetMessageID(1)
+
+	require.NoError(t, err)
+	got, err := cc.Do(getReq)
+	require.NoError(t, err)
+	require.Equal(t, codes.Content.String(), got.Code().String())
+
+	// New request but with DELETE code to trigger EOF error from request monitor
+	deleteReq, err := cc.NewDeleteRequest(ctx, "/test")
+	require.NoError(t, err)
+	deleteReq.SetMessageID(2)
+	_, err = cc.Do(deleteReq)
+	require.Error(t, err)
+	<-closeConn
+	require.True(t, isEOF.Load())
 }

--- a/tcp/client_test.go
+++ b/tcp/client_test.go
@@ -669,7 +669,7 @@ func TestClientKeepAliveMonitor(t *testing.T) {
 	require.True(t, inactivityDetected.Load())
 }
 
-func TestConnRequestMonitor(t *testing.T) {
+func TestConnRequestMonitorCloseConnection(t *testing.T) {
 	l, err := coapNet.NewTCPListener("tcp", "")
 	require.NoError(t, err)
 	defer func() {
@@ -695,11 +695,11 @@ func TestConnRequestMonitor(t *testing.T) {
 	testEOFError := errors.New("test error")
 	s := NewServer(
 		options.WithMux(m),
-		options.WithRequestMonitor(func(c *client.Conn, req *pool.Message) error {
+		options.WithRequestMonitor(func(c *client.Conn, req *pool.Message) (bool, error) {
 			if req.Code() == codes.DELETE {
-				return testEOFError
+				return false, testEOFError
 			}
-			return nil
+			return false, nil
 		}),
 		options.WithErrors(func(err error) {
 			t.Log(err)
@@ -753,4 +753,82 @@ func TestConnRequestMonitor(t *testing.T) {
 	_, err = cc.Do(deleteReq)
 	require.Error(t, err)
 	<-reqMonitorErr
+}
+
+func TestConnRequestMonitorDropRequest(t *testing.T) {
+	l, err := coapNet.NewTCPListener("tcp", "")
+	require.NoError(t, err)
+	defer func() {
+		errC := l.Close()
+		require.NoError(t, errC)
+	}()
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	m := mux.NewRouter()
+
+	// The response counts up with every get
+	// so we can check if the handler is only called once per message ID
+	err = m.Handle("/test", mux.HandlerFunc(func(w mux.ResponseWriter, r *mux.Message) {
+		errH := w.SetResponse(codes.Content, message.TextPlain, nil)
+		require.NoError(t, errH)
+	}))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	s := NewServer(
+		options.WithMux(m),
+		options.WithRequestMonitor(func(c *client.Conn, req *pool.Message) (bool, error) {
+			if req.Code() == codes.DELETE {
+				t.Log("drop request")
+				return true, nil
+			}
+			return false, nil
+		}),
+		options.WithErrors(func(err error) {
+			require.NoError(t, err)
+		}),
+		options.WithOnNewConn(func(c *client.Conn) {
+			t.Log("new conn")
+			c.AddOnClose(func() {
+				t.Log("close conn")
+			})
+		}))
+	defer s.Stop()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errS := s.Serve(l)
+		require.NoError(t, errS)
+	}()
+
+	cc, err := Dial(l.Addr().String(),
+		options.WithErrors(func(err error) {
+			t.Log(err)
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		errC := cc.Close()
+		require.NoError(t, errC)
+	}()
+
+	// Setup done - Run Tests
+	// Same request, executed twice (needs the same token)
+	getReq, err := cc.NewGetRequest(ctx, "/test")
+	getReq.SetMessageID(1)
+
+	require.NoError(t, err)
+	got, err := cc.Do(getReq)
+	require.NoError(t, err)
+	require.Equal(t, codes.Content.String(), got.Code().String())
+
+	// New request but with DELETE code to trigger EOF error from request monitor
+	deleteReq, err := cc.NewDeleteRequest(ctx, "/test")
+	require.NoError(t, err)
+	deleteReq.SetMessageID(2)
+	_, err = cc.Do(deleteReq)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, context.DeadlineExceeded))
 }

--- a/tcp/server/config.go
+++ b/tcp/server/config.go
@@ -41,8 +41,8 @@ var DefaultConfig = func() Config {
 		OnNewConn: func(cc *client.Conn) {
 			// do nothing by default
 		},
-		RequestMonitor: func(cc *client.Conn, req *pool.Message) error {
-			return nil
+		RequestMonitor: func(cc *client.Conn, req *pool.Message) (bool, error) {
+			return false, nil
 		},
 		ConnectionCacheSize: 2 * 1024,
 	}

--- a/tcp/server/config.go
+++ b/tcp/server/config.go
@@ -24,6 +24,9 @@ type GoPoolFunc = func(func()) error
 // OnNewConnFunc is the callback for new connections.
 type OnNewConnFunc = func(cc *client.Conn)
 
+// RequestMonitorFunc is the callback to see any requests.
+type RequestMonitorFunc = func(cc *client.Conn, req *pool.Message)
+
 var DefaultConfig = func() Config {
 	opts := Config{
 		Common: config.NewCommon[*client.Conn](),
@@ -41,6 +44,9 @@ var DefaultConfig = func() Config {
 		OnNewConn: func(cc *client.Conn) {
 			// do nothing by default
 		},
+		RequestMonitor: func(cc *client.Conn, req *pool.Message) {
+			// do nothing by default
+		},
 		ConnectionCacheSize: 2 * 1024,
 	}
 	opts.Handler = func(w *responsewriter.ResponseWriter[*client.Conn], r *pool.Message) {
@@ -56,6 +62,7 @@ type Config struct {
 	CreateInactivityMonitor         client.CreateInactivityMonitorFunc
 	Handler                         HandlerFunc
 	OnNewConn                       OnNewConnFunc
+	RequestMonitor                  RequestMonitorFunc
 	ConnectionCacheSize             uint16
 	DisablePeerTCPSignalMessageCSMs bool
 	DisableTCPSignalMessageCSM      bool

--- a/tcp/server/config.go
+++ b/tcp/server/config.go
@@ -24,9 +24,6 @@ type GoPoolFunc = func(func()) error
 // OnNewConnFunc is the callback for new connections.
 type OnNewConnFunc = func(cc *client.Conn)
 
-// RequestMonitorFunc is the callback to see any requests.
-type RequestMonitorFunc = func(cc *client.Conn, req *pool.Message)
-
 var DefaultConfig = func() Config {
 	opts := Config{
 		Common: config.NewCommon[*client.Conn](),
@@ -44,8 +41,8 @@ var DefaultConfig = func() Config {
 		OnNewConn: func(cc *client.Conn) {
 			// do nothing by default
 		},
-		RequestMonitor: func(cc *client.Conn, req *pool.Message) {
-			// do nothing by default
+		RequestMonitor: func(cc *client.Conn, req *pool.Message) error {
+			return nil
 		},
 		ConnectionCacheSize: 2 * 1024,
 	}
@@ -62,7 +59,7 @@ type Config struct {
 	CreateInactivityMonitor         client.CreateInactivityMonitorFunc
 	Handler                         HandlerFunc
 	OnNewConn                       OnNewConnFunc
-	RequestMonitor                  RequestMonitorFunc
+	RequestMonitor                  client.RequestMonitorFunc
 	ConnectionCacheSize             uint16
 	DisablePeerTCPSignalMessageCSMs bool
 	DisableTCPSignalMessageCSM      bool

--- a/tcp/server/server.go
+++ b/tcp/server/server.go
@@ -119,8 +119,9 @@ func (s *Server) checkAcceptError(err error) bool {
 
 func (s *Server) serveConnection(connections *connections.Connections, rw net.Conn) {
 	var cc *client.Conn
-	monitor := s.cfg.CreateInactivityMonitor()
-	cc = s.createConn(coapNet.NewConn(rw), monitor)
+	inactivityMonitor := s.cfg.CreateInactivityMonitor()
+	requestMonitor := s.cfg.RequestMonitor
+	cc = s.createConn(coapNet.NewConn(rw), inactivityMonitor, requestMonitor)
 	if s.cfg.OnNewConn != nil {
 		s.cfg.OnNewConn(cc)
 	}
@@ -182,7 +183,7 @@ func (s *Server) Stop() {
 	}
 }
 
-func (s *Server) createConn(connection *coapNet.Conn, monitor client.InactivityMonitor) *client.Conn {
+func (s *Server) createConn(connection *coapNet.Conn, inactivityMonitor client.InactivityMonitor, requestMonitor RequestMonitorFunc) *client.Conn {
 	createBlockWise := func(cc *client.Conn) *blockwise.BlockWise[*client.Conn] {
 		return nil
 	}
@@ -215,7 +216,8 @@ func (s *Server) createConn(connection *coapNet.Conn, monitor client.InactivityM
 	cc := client.NewConn(
 		connection,
 		createBlockWise,
-		monitor,
+		inactivityMonitor,
+		requestMonitor,
 		&cfg,
 	)
 

--- a/tcp/server/server.go
+++ b/tcp/server/server.go
@@ -183,7 +183,7 @@ func (s *Server) Stop() {
 	}
 }
 
-func (s *Server) createConn(connection *coapNet.Conn, inactivityMonitor client.InactivityMonitor, requestMonitor RequestMonitorFunc) *client.Conn {
+func (s *Server) createConn(connection *coapNet.Conn, inactivityMonitor client.InactivityMonitor, requestMonitor client.RequestMonitorFunc) *client.Conn {
 	createBlockWise := func(cc *client.Conn) *blockwise.BlockWise[*client.Conn] {
 		return nil
 	}
@@ -213,12 +213,12 @@ func (s *Server) createConn(connection *coapNet.Conn, inactivityMonitor client.I
 	cfg.GetToken = s.cfg.GetToken
 	cfg.ProcessReceivedMessage = s.cfg.ProcessReceivedMessage
 	cfg.ReceivedMessageQueueSize = s.cfg.ReceivedMessageQueueSize
-	cc := client.NewConn(
+	cc := client.NewConnWithOpts(
 		connection,
-		createBlockWise,
-		inactivityMonitor,
-		requestMonitor,
 		&cfg,
+		client.WithBlockWise(createBlockWise),
+		client.WithInactivityMonitor(inactivityMonitor),
+		client.WithRequestMonitor(requestMonitor),
 	)
 
 	return cc

--- a/udp/client.go
+++ b/udp/client.go
@@ -58,11 +58,6 @@ func Client(conn *net.UDPConn, opts ...Option) *client.Conn {
 	if cfg.MessagePool == nil {
 		cfg.MessagePool = pool.New(0, 0)
 	}
-	if cfg.RequestMonitor == nil {
-		cfg.RequestMonitor = func(*client.Conn, *pool.Message) error {
-			return nil
-		}
-	}
 
 	errorsFunc := cfg.Errors
 	cfg.Errors = func(err error) {

--- a/udp/client/config.go
+++ b/udp/client/config.go
@@ -21,8 +21,8 @@ var DefaultConfig = func() Config {
 		CreateInactivityMonitor: func() InactivityMonitor {
 			return inactivity.NewNilMonitor[*Conn]()
 		},
-		RequestMonitor: func(*Conn, *pool.Message) error {
-			return nil
+		RequestMonitor: func(*Conn, *pool.Message) (bool, error) {
+			return false, nil
 		},
 		Dialer:                         &net.Dialer{Timeout: time.Second * 3},
 		Net:                            "udp",

--- a/udp/client/config.go
+++ b/udp/client/config.go
@@ -21,6 +21,9 @@ var DefaultConfig = func() Config {
 		CreateInactivityMonitor: func() InactivityMonitor {
 			return inactivity.NewNilMonitor[*Conn]()
 		},
+		RequestMonitor: func(*Conn, *pool.Message) error {
+			return nil
+		},
 		Dialer:                         &net.Dialer{Timeout: time.Second * 3},
 		Net:                            "udp",
 		TransmissionNStart:             1,
@@ -43,6 +46,7 @@ var DefaultConfig = func() Config {
 type Config struct {
 	config.Common[*Conn]
 	CreateInactivityMonitor        CreateInactivityMonitorFunc
+	RequestMonitor                 RequestMonitorFunc
 	Net                            string
 	GetMID                         GetMIDFunc
 	Handler                        HandlerFunc

--- a/udp/client/conn.go
+++ b/udp/client/conn.go
@@ -792,10 +792,6 @@ func (cc *Conn) handlePong(w *responsewriter.ResponseWriter[*Conn], r *pool.Mess
 	cc.sendPong(w, r)
 }
 
-func (cc *Conn) IsPingMessage(r *pool.Message) bool {
-	return r.Code() == codes.Empty && r.Type() == message.Confirmable && len(r.Token()) == 0 && len(r.Options()) == 0 && r.Body() == nil
-}
-
 func upsertInterfaceToMessage(m *pool.Message, ifIndex int) {
 	if ifIndex >= 1 {
 		cm := coapNet.ControlMessage{
@@ -807,7 +803,7 @@ func upsertInterfaceToMessage(m *pool.Message, ifIndex int) {
 
 func (cc *Conn) handleSpecialMessages(r *pool.Message) bool {
 	// ping request
-	if cc.IsPingMessage(r) {
+	if r.IsPing(false) {
 		cc.ProcessReceivedMessageWithHandler(r, cc.handlePong)
 		return true
 	}

--- a/udp/client/conn_test.go
+++ b/udp/client/conn_test.go
@@ -854,8 +854,10 @@ func TestConnRequestMonitorCloseConnection(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*8)
 	defer cancel()
+	ctxRegMonitor, cancelReqMonitor := context.WithCancel(ctx)
+	defer cancelReqMonitor()
 	reqMonitorErr := make(chan struct{}, 1)
 	testEOFError := errors.New("test error")
 	s := udp.NewServer(
@@ -872,7 +874,7 @@ func TestConnRequestMonitorCloseConnection(t *testing.T) {
 				if errors.Is(err, testEOFError) {
 					select {
 					case reqMonitorErr <- struct{}{}:
-						cancel()
+						cancelReqMonitor()
 					default:
 					}
 				}
@@ -914,12 +916,16 @@ func TestConnRequestMonitorCloseConnection(t *testing.T) {
 	require.Equal(t, codes.Content.String(), got.Code().String())
 
 	// New request but with DELETE code to trigger EOF error from request monitor
-	deleteReq, err := cc.NewDeleteRequest(ctx, "/test")
+	deleteReq, err := cc.NewDeleteRequest(ctxRegMonitor, "/test")
 	require.NoError(t, err)
 	deleteReq.SetMessageID(2)
 	_, err = cc.Do(deleteReq)
 	require.Error(t, err)
-	<-reqMonitorErr
+	select {
+	case <-reqMonitorErr:
+	case <-ctx.Done():
+		require.Fail(t, "request monitor not called")
+	}
 }
 
 func TestConnRequestMonitorDropRequest(t *testing.T) {

--- a/udp/client/conn_test.go
+++ b/udp/client/conn_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/plgd-dev/go-coap/v3/udp/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 const testNumParallel = 64
@@ -47,13 +47,13 @@ func TestConnDeduplication(t *testing.T) {
 
 	m := mux.NewRouter()
 
-	cnt := int32(0)
+	var cnt atomic.Int32
 	// The response counts up with every get
 	// so we can check if the handler is only called once per message ID
 	err = m.Handle("/count", mux.HandlerFunc(func(w mux.ResponseWriter, r *mux.Message) {
 		assert.Equal(t, codes.GET, r.Code())
-		atomic.AddInt32(&cnt, 1)
-		errH := w.SetResponse(codes.Content, message.AppOctets, bytes.NewReader([]byte{byte(cnt)}))
+		cnt.Add(1)
+		errH := w.SetResponse(codes.Content, message.AppOctets, bytes.NewReader([]byte{byte(cnt.Load())}))
 		require.NoError(t, errH)
 		require.NotEmpty(t, w.Conn())
 	}))
@@ -126,14 +126,14 @@ func TestConnDeduplicationRetransmission(t *testing.T) {
 
 	m := mux.NewRouter()
 
-	cnt := int32(0)
+	var cnt atomic.Int32
 	// The response counts up with every get
 	// so we can check if the handler is only called once per message ID
 	once := sync.Once{}
 	err = m.Handle("/count", mux.HandlerFunc(func(w mux.ResponseWriter, r *mux.Message) {
 		assert.Equal(t, codes.GET, r.Code())
-		atomic.AddInt32(&cnt, 1)
-		errH := w.SetResponse(codes.Content, message.AppOctets, bytes.NewReader([]byte{byte(cnt)}))
+		cnt.Add(1)
+		errH := w.SetResponse(codes.Content, message.AppOctets, bytes.NewReader([]byte{byte(cnt.Load())}))
 		require.NoError(t, errH)
 
 		// Only one delay to trigger retransmissions
@@ -832,4 +832,93 @@ func TestConnPing(t *testing.T) {
 	defer cancel()
 	err = cc.Ping(ctx)
 	require.NoError(t, err)
+}
+
+func TestConnRequestMonitor(t *testing.T) {
+	l, err := coapNet.NewListenUDP("udp", "")
+	require.NoError(t, err)
+	defer func() {
+		errC := l.Close()
+		require.NoError(t, errC)
+	}()
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	m := mux.NewRouter()
+
+	// The response counts up with every get
+	// so we can check if the handler is only called once per message ID
+	err = m.Handle("/test", mux.HandlerFunc(func(w mux.ResponseWriter, r *mux.Message) {
+		errH := w.SetResponse(codes.Content, message.TextPlain, nil)
+		require.NoError(t, errH)
+	}))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*60)
+	defer cancel()
+	closeConn := make(chan struct{}, 1)
+	var isEOF atomic.Bool
+	testEOFError := errors.New("test error")
+	s := udp.NewServer(
+		options.WithMux(m),
+		options.WithRequestMonitor(func(c *client.Conn, req *pool.Message) error {
+			if req.Code() == codes.DELETE {
+				return testEOFError
+			}
+			return nil
+		}),
+		options.WithErrors(func(err error) {
+			t.Log(err)
+			if errors.Is(err, testEOFError) {
+				isEOF.Store(true)
+			}
+		}),
+		options.WithOnNewConn(func(c *client.Conn) {
+			t.Log("new conn")
+			c.AddOnClose(func() {
+				t.Log("close conn")
+				select {
+				case closeConn <- struct{}{}:
+					cancel()
+				default:
+				}
+			})
+		}))
+	defer s.Stop()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errS := s.Serve(l)
+		require.NoError(t, errS)
+	}()
+
+	cc, err := udp.Dial(l.LocalAddr().String(),
+		options.WithErrors(func(err error) {
+			t.Log(err)
+		}),
+	)
+	require.NoError(t, err)
+	defer func() {
+		errC := cc.Close()
+		require.NoError(t, errC)
+	}()
+
+	// Setup done - Run Tests
+	// Same request, executed twice (needs the same token)
+	getReq, err := cc.NewGetRequest(ctx, "/test")
+	getReq.SetMessageID(1)
+
+	require.NoError(t, err)
+	got, err := cc.Do(getReq)
+	require.NoError(t, err)
+	require.Equal(t, codes.Content.String(), got.Code().String())
+
+	// New request but with DELETE code to trigger EOF error from request monitor
+	deleteReq, err := cc.NewDeleteRequest(ctx, "/test")
+	require.NoError(t, err)
+	deleteReq.SetMessageID(2)
+	_, err = cc.Do(deleteReq)
+	require.Error(t, err)
+	<-closeConn
+	require.True(t, isEOF.Load())
 }

--- a/udp/server/config.go
+++ b/udp/server/config.go
@@ -37,8 +37,8 @@ var DefaultConfig = func() Config {
 		OnNewConn: func(cc *udpClient.Conn) {
 			// do nothing by default
 		},
-		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) error {
-			return nil
+		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) (bool, error) {
+			return false, nil
 		},
 		TransmissionNStart:             1,
 		TransmissionAcknowledgeTimeout: time.Second * 2,

--- a/udp/server/config.go
+++ b/udp/server/config.go
@@ -22,9 +22,6 @@ type ErrorFunc = func(error)
 // OnNewConnFunc is the callback for new connections.
 type OnNewConnFunc = func(cc *udpClient.Conn)
 
-// RequestMonitorFunc is the callback to see any requests.
-type RequestMonitorFunc = func(cc *udpClient.Conn, req *pool.Message)
-
 type GetMIDFunc = func() int32
 
 var DefaultConfig = func() Config {
@@ -40,8 +37,8 @@ var DefaultConfig = func() Config {
 		OnNewConn: func(cc *udpClient.Conn) {
 			// do nothing by default
 		},
-		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) {
-			// do nothing by default
+		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) error {
+			return nil
 		},
 		TransmissionNStart:             1,
 		TransmissionAcknowledgeTimeout: time.Second * 2,
@@ -63,7 +60,7 @@ type Config struct {
 	GetMID                         GetMIDFunc
 	Handler                        HandlerFunc
 	OnNewConn                      OnNewConnFunc
-	RequestMonitor                 RequestMonitorFunc
+	RequestMonitor                 udpClient.RequestMonitorFunc
 	TransmissionNStart             uint32
 	TransmissionAcknowledgeTimeout time.Duration
 	TransmissionMaxRetransmit      uint32

--- a/udp/server/config.go
+++ b/udp/server/config.go
@@ -22,6 +22,9 @@ type ErrorFunc = func(error)
 // OnNewConnFunc is the callback for new connections.
 type OnNewConnFunc = func(cc *udpClient.Conn)
 
+// RequestMonitorFunc is the callback to see any requests.
+type RequestMonitorFunc = func(cc *udpClient.Conn, req *pool.Message)
+
 type GetMIDFunc = func() int32
 
 var DefaultConfig = func() Config {
@@ -35,6 +38,9 @@ var DefaultConfig = func() Config {
 			return inactivity.New(timeout, onInactive)
 		},
 		OnNewConn: func(cc *udpClient.Conn) {
+			// do nothing by default
+		},
+		RequestMonitor: func(cc *udpClient.Conn, req *pool.Message) {
 			// do nothing by default
 		},
 		TransmissionNStart:             1,
@@ -57,6 +63,7 @@ type Config struct {
 	GetMID                         GetMIDFunc
 	Handler                        HandlerFunc
 	OnNewConn                      OnNewConnFunc
+	RequestMonitor                 RequestMonitorFunc
 	TransmissionNStart             uint32
 	TransmissionAcknowledgeTimeout time.Duration
 	TransmissionMaxRetransmit      uint32

--- a/udp/server/server.go
+++ b/udp/server/server.go
@@ -323,10 +323,12 @@ func (s *Server) getOrCreateConn(udpConn *coapNet.UDPConn, raddr *net.UDPAddr) (
 	cfg.ProcessReceivedMessage = s.cfg.ProcessReceivedMessage
 	cfg.ReceivedMessageQueueSize = s.cfg.ReceivedMessageQueueSize
 
+	requestMonitor := s.cfg.RequestMonitor
 	cc = client.NewConn(
 		session,
 		createBlockWise,
 		monitor,
+		requestMonitor,
 		&cfg,
 	)
 	cc.SetContextValue(closeKey, func() {

--- a/udp/server/server.go
+++ b/udp/server/server.go
@@ -324,12 +324,12 @@ func (s *Server) getOrCreateConn(udpConn *coapNet.UDPConn, raddr *net.UDPAddr) (
 	cfg.ReceivedMessageQueueSize = s.cfg.ReceivedMessageQueueSize
 
 	requestMonitor := s.cfg.RequestMonitor
-	cc = client.NewConn(
+	cc = client.NewConnWithOpts(
 		session,
-		createBlockWise,
-		monitor,
-		requestMonitor,
 		&cfg,
+		client.WithInactivityMonitor(monitor),
+		client.WithRequestMonitor(requestMonitor),
+		client.WithBlockWise(createBlockWise),
 	)
 	cc.SetContextValue(closeKey, func() {
 		if err := session.Close(); err != nil {


### PR DESCRIPTION
This pull request introduces a new feature to the CoAP connection module - Request Monitoring. The `WithRequestMonitor` function has been implemented to enable request monitoring for the connection. This function is called for each CoAP message received from the peer before it is processed.

Details of the Feature:
- **Functionality:** `WithRequestMonitor` allows developers to implement custom request monitoring logic for incoming CoAP messages.
- **Error Handling:** If the function returns an error, the connection is closed, providing a mechanism to handle and respond to issues in the monitoring process.
- **Message Dropping:** If the function returns true, the incoming message is dropped, allowing for selective handling or filtering of messages based on monitoring criteria.

This new feature enhances the flexibility and control developers have over the CoAP connection behavior. Please review the changes and provide feedback.