### PR TITLE
Enhance Options Buffer for >16 Message Unmarshaling

### DIFF
--- a/message/pool/message_test.go
+++ b/message/pool/message_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/plgd-dev/go-coap/v3/message"
 	"github.com/plgd-dev/go-coap/v3/message/pool"
+	"github.com/plgd-dev/go-coap/v3/tcp/coder"
 	"github.com/plgd-dev/go-coap/v3/test/net"
 	"github.com/stretchr/testify/require"
 )
@@ -359,4 +361,33 @@ func TestMessageClone(t *testing.T) {
 	err = original.Clone(cloned)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "read error")
+}
+
+func TestUnmarshalMessageWithMultipleOptions(t *testing.T) {
+	tests := []struct {
+		numOptions int
+	}{
+		{numOptions: 0},
+		{numOptions: 8},
+		{numOptions: 16},
+		{numOptions: 32},
+		{numOptions: 64},
+		{numOptions: 1023},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("num-options-%v", tt.numOptions), func(t *testing.T) {
+			req := pool.NewMessage(context.Background())
+			for i := 0; i < 64; i++ {
+				req.AddOptionUint32(message.URIQuery, uint32(i))
+			}
+			data, err := req.MarshalWithEncoder(coder.DefaultCoder)
+			require.NoError(t, err)
+			msg := pool.NewMessage(context.Background())
+			n, err := msg.UnmarshalWithDecoder(coder.DefaultCoder, data)
+			require.NoError(t, err)
+			require.Equal(t, n, len(data))
+			require.Equal(t, req.Options(), msg.Options())
+		})
+	}
 }


### PR DESCRIPTION
Previously, the connection was being closed due to unmarshaling failures when more than 16 options were included in the message. This fix addresses the issue by increasing the buffer size to accommodate a higher number of options.