### PR TITLE
Fix UDP Server Option Duplication in ListenAndServeWithOptions

### DIFF
--- a/server.go
+++ b/server.go
@@ -91,6 +91,11 @@ func ListenAndServeWithOptions(network, addr string, opts ...any) (err error) {
 		switch o := opt.(type) {
 		case tcpServer.Option:
 			tcpOptions = append(tcpOptions, o)
+
+			// Duplicate the option for UDP if needed.
+			if udpOpt, ok := o.(udpServer.Option); ok {
+				udpOptions = append(udpOptions, udpOpt)
+			}
 		case udpServer.Option:
 			udpOptions = append(udpOptions, o)
 		default:


### PR DESCRIPTION
This change ensures that when a UDP option is provided in the options list, it is appropriately added to both the TCP and UDP option slices, ensuring consistent behavior for both server types.

#526 
