### PR TITLE
Blockwise progress

### DIFF
--- a/net/blockwise/blockwise.go
+++ b/net/blockwise/blockwise.go
@@ -391,10 +391,10 @@ func (b *BlockWise[C]) handleReceivedMessage(w *responsewriter.ResponseWriter[C]
 	case codes.GET, codes.DELETE:
 		maxSZX = fitSZX(r, message.Block2, maxSZX)
 		block, errG := r.GetOptionUint32(message.Block2)
+		next(w, r)
 		if errG == nil {
 			r.Remove(message.Block2)
 		}
-		next(w, r)
 		if w.Message().Code() == codes.Content && errG == nil {
 			startSendingMessageBlock = block
 		}


### PR DESCRIPTION
Do not remove the block until AFTER the next() call so that handler can access the Block2 option. This allows the handle to keep track of the transfer. For example, keeping track of Block X of Y, or report status every 50 blocks, or on last block signal a completion event

Closes #236