### PR TITLE
Fix CoAP ping response over unreliable transport

### DIFF
--- a/udp/client/conn.go
+++ b/udp/client/conn.go
@@ -646,15 +646,9 @@ func (cc *Conn) sendPong(w *responsewriter.ResponseWriter[*Conn], r *pool.Messag
 	if err := w.SetResponse(codes.Empty, message.TextPlain, nil); err != nil {
 		cc.errors(fmt.Errorf("cannot send pong response: %w", err))
 	}
-	if r.Type() == message.Confirmable {
-		w.Message().SetType(message.Acknowledgement)
-		w.Message().SetMessageID(r.MessageID())
-	} else {
-		if w.Message().Type() != message.Reset {
-			w.Message().SetType(message.NonConfirmable)
-		}
-		w.Message().SetMessageID(cc.GetMessageID())
-	}
+	w.Message().SetType(message.Reset)
+	w.Message().SetMessageID(r.MessageID())
+
 }
 
 func (cc *Conn) handle(w *responsewriter.ResponseWriter[*Conn], m *pool.Message) {


### PR DESCRIPTION
As per RFC 7252, the CoAP ping (empty, confirmable message) must be responded to with a reset message.

Resolves #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the messaging response process to ensure a more consistent and reliable experience. Responses are now handled uniformly, enhancing overall communication efficiency while maintaining robust error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->