### PR TITLE
Fix sending to IPv4 addresses from an IPv6 dual-stack socket (#640)

### DIFF
--- a/net/connUDP_internal_test.go
+++ b/net/connUDP_internal_test.go
@@ -21,14 +21,9 @@ const (
 
 func TestUDPConnWriteWithContext(t *testing.T) {
 	iface := getInterfaceIndex(t)
-
 	ifaceIpv4 := getIfaceAddr(t, iface, true)
 	peerAddr := ifaceIpv4.String() + ":2154"
 	b, err := net.ResolveUDPAddr(udpNetwork, peerAddr)
-	require.NoError(t, err)
-
-	ifaceIpv6 := getIfaceAddr(t, iface, false)
-	v6, err := net.ResolveUDPAddr(udpNetwork, "["+ifaceIpv6.String()+"]:2154")
 	require.NoError(t, err)
 
 	ctxCanceled, ctxCancel := context.WithCancel(context.Background())
@@ -73,16 +68,6 @@ func TestUDPConnWriteWithContext(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
-			name: "send to v6 from v6 socket",
-			args: args{
-				ctx:           context.Background(),
-				listenNetwork: udpNetwork,
-				udpAddr:       v6,
-				buffer:        []byte("hello world"),
-			},
-			wantErr: false,
-		},
 	}
 	if runtime.GOOS == "linux" {
 		tests = append(tests, struct {
@@ -100,26 +85,26 @@ func TestUDPConnWriteWithContext(t *testing.T) {
 		})
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	l2, err := net.ListenUDP(udpNetwork, b)
+	require.NoError(t, err)
+	c2 := NewUDPConn(udpNetwork, l2, WithErrors(func(err error) { t.Log(err) }))
+	defer func() {
+		errC := c2.Close()
+		require.NoError(t, errC)
+	}()
+
+	go func() {
+		b := make([]byte, 1024)
+		_, _, errR := c2.ReadWithContext(ctx, b)
+		if errR != nil {
+			return
+		}
+	}()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			l2, err := net.ListenUDP(udpNetwork, tt.args.udpAddr)
-			require.NoError(t, err)
-			c2 := NewUDPConn(udpNetwork, l2, WithErrors(func(err error) { t.Log(err) }))
-			defer func() {
-				errC := c2.Close()
-				require.NoError(t, errC)
-			}()
-
-			go func() {
-				b := make([]byte, 1024)
-				_, _, errR := c2.ReadWithContext(ctx, b)
-				if errR != nil {
-					return
-				}
-			}()
-
 			a, err := net.ResolveUDPAddr(tt.args.listenNetwork, ":")
 			require.NoError(t, err)
 			l1, err := net.ListenUDP(tt.args.listenNetwork, a)
@@ -352,10 +337,7 @@ func getIfaceAddr(t *testing.T, iface net.Interface, ipv4 bool) net.IP {
 			t.Logf("Error parsing CIDR: %v", err)
 			continue
 		}
-		if !ip.IsPrivate() && !ip.IsGlobalUnicast() {
-			continue
-		}
-		if (!ipv4 && ip.To4() == nil) || (ipv4 && ip.To4() != nil) {
+		if ip.IsPrivate() && (!ipv4 || ip.To4() != nil) {
 			selectedIP = ip
 			break
 		}
@@ -471,7 +453,7 @@ func TestUDPConnWriteToAddr(t *testing.T) {
 			}
 			network := udp4Network
 			ip := getIfaceAddr(t, iface, true)
-			if IsIPv6(tt.args.src) || IsIPv6(tt.args.raddr.IP) {
+			if IsIPv6(tt.args.src) {
 				network = udp6Network
 				ip = getIfaceAddr(t, iface, false)
 			}

--- a/net/tlslistener_test.go
+++ b/net/tlslistener_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"net"
 	"os"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -225,12 +224,7 @@ func TestTLSListenerCheckForInfinitLoop(t *testing.T) {
 			c := coapNet.NewConn(con)
 			_, err = c.ReadWithContext(context.Background(), b)
 			require.Error(t, err)
-			t.Log(err.Error())
-			if runtime.GOOS == "darwin" {
-				assert.Contains(t, err.Error(), "connection reset by peer")
-			} else {
-				assert.Contains(t, err.Error(), "EOF")
-			}
+			assert.Contains(t, err.Error(), "EOF")
 			err = con.Close()
 			require.Error(t, err)
 		})


### PR DESCRIPTION
This PR resolves sending packets to IPv4 adresses on an IPv6 dual-stack socket. It resolves #640 and is probably related to #581.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP connection handling for IPv4/IPv6 compatibility, enabling better message transmission between different protocol versions.

* **Tests**
  * Added test coverage for sending IPv4 traffic from IPv6 sockets to ensure cross-protocol compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->