### PR TITLE
chore: bump Go baseline to 1.24 and update CI/test compatibility

### DIFF
--- a/.github/workflows/staticAnalysis.yml
+++ b/.github/workflows/staticAnalysis.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up Go 1.20+
+      - name: Set up Go 1.24+
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.20" # The Go version to download (if necessary) and use.
+          go-version: "^1.24" # The Go version to download (if necessary) and use.
           check-latest: true
 
       - run: go version

--- a/.github/workflows/test-for-fork.yml
+++ b/.github/workflows/test-for-fork.yml
@@ -14,18 +14,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - name: Set up Go 1.20-1.25 (Windows)
+      - name: Set up Go 1.24-1.25 (Windows)
         if: runner.os == 'Windows'
         uses: actions/setup-go@v6
         with:
-          go-version: ">=1.20 <1.26" # Temporary cap: Go 1.26 has a CI bug on Windows.
+          go-version: ">=1.24 <1.26" # Temporary cap: Go 1.26 has a CI bug on Windows.
           check-latest: true
 
-      - name: Set up Go 1.20+ (Non-Windows)
+      - name: Set up Go 1.24+ (Non-Windows)
         if: runner.os != 'Windows'
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.20"
+          go-version: "^1.24"
           check-latest: true
 
       - run: go version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
           directory: .tmp/
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,18 +23,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - name: Set up Go 1.20-1.25 (Windows)
+      - name: Set up Go 1.24-1.25 (Windows)
         if: runner.os == 'Windows'
         uses: actions/setup-go@v6
         with:
-          go-version: ">=1.20 <1.26" # Temporary cap: Go 1.26 has a CI bug on Windows.
+          go-version: ">=1.24 <1.26" # Temporary cap: Go 1.26 has a CI bug on Windows.
           check-latest: true
 
-      - name: Set up Go 1.20+ (Non-Windows)
+      - name: Set up Go 1.24+ (Non-Windows)
         if: runner.os != 'Windows'
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.20"
+          go-version: "^1.24"
           check-latest: true
 
       - run: go version
@@ -119,10 +119,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.20
+      - name: Set up Go 1.24
         uses: actions/setup-go@v6
         with:
-          go-version: "~1.20"
+          go-version: "~1.24"
 
       - run: go version
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,6 +124,7 @@ linters:
           - gocyclo
           - gosec
           - nakedret
+          - perfsprint
         path: _test\.go
       - linters:
           - dupl
@@ -143,6 +144,18 @@ linters:
           - godox
         path: .*.go
         text: replace with standard maps package
+      - linters:
+          - revive
+        path: '^dtls/clientoptions\.go'
+        text: 'stutters; consider calling this Client(Options|Config)'
+      - linters:
+          - revive
+        path: '^(pkg/errors/error\.go|pkg/math/cast\.go|test/net/uri\.go|net/.*\.go)$'
+        text: 'avoid package names that conflict with Go standard library package names'
+      - linters:
+          - staticcheck
+        path: '^(dtls/client\.go|dtls/client_test\.go|dtls/clientoptions\.go|dtls/server_test\.go|dtls/example_test\.go|net/dtlslistener\.go|net/dtlsoptions\.go)$'
+        text: 'SA1019: (piondtls\.(Config|Dial)|dtls\.Config) is deprecated'
     # Which file paths to exclude: they will be analyzed, but issues from them won't be reported.
     # "/" will be replaced by the current OS file path separator to properly work on Windows.
     # Default: []

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.20"
+  go: "1.24"
 # issues:
 #   fix: true
 linters:
@@ -46,7 +46,7 @@ linters:
     - nestif           # Reports deeply nested if statements
     - nilerr           # Finds the code that returns nil even if it checks that the error is not nil.
     - nilnil           # Checks that there is no simultaneous return of `nil` error and an invalid value.
-    # - noctx            # noctx finds sending http request without context.Context - Some occurrences are not support in go1.20
+    # - noctx            # noctx finds sending http request without context.Context - Some occurrences are not support in go1.24
     - nolintlint       # Reports ill-formed or insufficient nolint directives
     - nosprintfhostport # Checks for misuse of Sprintf to construct a host with port in a URL
     - perfsprint       # Checks that fmt.Sprintf can be replaced with a faster alternative.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The go-coap provides servers and clients for DTLS, TCP-TLS, UDP, TCP in golang l
 
 ## Requirements
 
-* Go 1.20 or higher
+* Go 1.24 or higher
 
 ## Samples
 

--- a/net/tlslistener_test.go
+++ b/net/tlslistener_test.go
@@ -227,8 +227,9 @@ func TestTLSListenerCheckForInfinitLoop(t *testing.T) {
 			require.Error(t, err)
 			// On macOS a RST during TLS handshake yields "connection reset by peer" instead of EOF;
 			// both indicate the remote side closed the connection.
+			// On Windows, the error message is "connection was forcibly closed by the remote host".
 			assert.True(t,
-				strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "connection reset by peer"),
+				strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "connection reset by peer") || strings.Contains(err.Error(), "connection was forcibly closed by the remote host"),
 				"expected EOF or connection reset by peer, got: %v", err,
 			)
 			err = con.Close()


### PR DESCRIPTION
- Raise Go version requirements from 1.20 to 1.24 in CI workflows, lint config, and project docs.
- Keep Windows CI capped below Go 1.26 as noted in workflow comments.
- Expand TLS listener test error assertion to also accept the Windows-specific remote-close message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI and test workflows updated to use Go 1.24+ and related toolchain updates; CI scanning action also upgraded.
  * Linting configuration adjusted to target Go 1.24 and added targeted rule suppressions for specific files/patterns.

* **Documentation**
  * README now requires Go 1.24 or higher.

* **Tests**
  * Windows TLS listener test updated to accept an additional Windows-specific connection error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->