### PR TITLE
659 bug blockwise windows udp

### DIFF
--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -517,24 +517,17 @@ func (c *UDPConn) writeTo(raddr *net.UDPAddr, cm *ControlMessage, buffer []byte)
 		return c.connection.Write(buffer)
 	}
 
-	var cmb []byte
-
-	if cm != nil && IsIPv6(raddr.IP) {
-		m := &ipv6.ControlMessage{
-			Src:     cm.Src,
-			IfIndex: cm.IfIndex,
-		}
-		cmb = m.Marshal()
-	} else if cm != nil {
-		m := &ipv4.ControlMessage{
-			Src:     cm.Src,
-			IfIndex: cm.IfIndex,
-		}
-		cmb = m.Marshal()
+	// For an unconnected listener we use the ipv4/ipv6 PacketConn.WriteTo wrapper
+	// instead of the raw (*net.UDPConn).WriteMsgUDP. On Windows WriteMsgUDP reports
+	// n=0 even though the datagram is delivered correctly, which made writeWithCfg
+	// treat every server response as a partial write (ErrWriteInterrupted) and broke
+	// blockwise transfers (endless request/response loop). PacketConn.WriteTo returns
+	// the correct number of written bytes on all platforms.
+	p, err := newPacketConnWithAddr(raddr, c.connection)
+	if err != nil {
+		return 0, err
 	}
-
-	i, _, err := c.connection.WriteMsgUDP(buffer, cmb, raddr)
-	return i, err
+	return p.WriteTo(buffer, cm, raddr)
 }
 
 type UDPWriteCfg struct {

--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -408,22 +408,22 @@ func (c *UDPConn) writeMulticastWithInterface(raddr *net.UDPAddr, buffer []byte,
 	if IsIPv6(raddr.IP) {
 		netType = "udp6"
 	}
-	var errors []error
+	var errs []error
 	for _, ip := range convAddrsToIps(filterAddressesByNetwork(netType, ifaceAddrs)) {
 		ipAddr := ip
 		opt.Source = &ipAddr
 		err = c.writeToAddr(opt.Iface, opt.Source, opt.HopLimit, raddr, buffer)
 		if err != nil {
-			errors = append(errors, err)
+			errs = append(errs, err)
 		}
 	}
-	if errors == nil {
+	if errs == nil {
 		return nil
 	}
-	if len(errors) == 1 {
-		return errors[0]
+	if len(errs) == 1 {
+		return errs[0]
 	}
-	return fmt.Errorf("%v", errors)
+	return fmt.Errorf("%v", errs)
 }
 
 func (c *UDPConn) writeMulticastToAllInterfaces(raddr *net.UDPAddr, buffer []byte, opt MulticastOptions) error {
@@ -432,7 +432,7 @@ func (c *UDPConn) writeMulticastToAllInterfaces(raddr *net.UDPAddr, buffer []byt
 		return fmt.Errorf("cannot get interfaces for multicast connection: %w", err)
 	}
 
-	var errors []error
+	var errs []error
 	for i := range ifaces {
 		iface := ifaces[i]
 		if iface.Flags&net.FlagMulticast == 0 {
@@ -450,16 +450,16 @@ func (c *UDPConn) writeMulticastToAllInterfaces(raddr *net.UDPAddr, buffer []byt
 				opt.InterfaceError(&iface, err)
 				continue
 			}
-			errors = append(errors, err)
+			errs = append(errs, err)
 		}
 	}
-	if errors == nil {
+	if errs == nil {
 		return nil
 	}
-	if len(errors) == 1 {
-		return errors[0]
+	if len(errs) == 1 {
+		return errs[0]
 	}
-	return fmt.Errorf("%v", errors)
+	return fmt.Errorf("%v", errs)
 }
 
 func (c *UDPConn) validateMulticast(ctx context.Context, raddr *net.UDPAddr, opt MulticastOptions) error {
@@ -519,13 +519,26 @@ func (c *UDPConn) writeTo(raddr *net.UDPAddr, cm *ControlMessage, buffer []byte)
 
 	// For an unconnected listener we use the ipv4/ipv6 PacketConn.WriteTo wrapper
 	// instead of the raw (*net.UDPConn).WriteMsgUDP. On Windows WriteMsgUDP reports
-	// n=0 even though the datagram is delivered correctly, which made writeWithCfg
-	// treat every server response as a partial write (ErrWriteInterrupted) and broke
-	// blockwise transfers (endless request/response loop). PacketConn.WriteTo returns
-	// the correct number of written bytes on all platforms.
-	p, err := newPacketConnWithAddr(raddr, c.connection)
-	if err != nil {
-		return 0, err
+	// n=0 even though the datagram is delivered correctly. Historically this made
+	// writeWithCfg treat every server response as a partial write (ErrWriteInterrupted)
+	// and broke blockwise transfers (endless request/response loop). PacketConn.WriteTo
+	// returns the correct number of written bytes on all platforms.
+	//
+	// Note: writeWithCfg also guards against a bogus n=0 result, so the two changes are
+	// defense-in-depth - this wrapper reports the right byte count, and the caller no
+	// longer misinterprets a zero-length report as a partial write.
+	//
+	// Reuse the listener's cached packetConn when its address family matches the
+	// destination. Only on a family mismatch (e.g. a dual-stack socket replying to
+	// the other family) do we build a matching one. This avoids a per-write
+	// allocation and SetControlMessage syscall on the hot response path.
+	p := c.packetConn
+	if p == nil || p.IsIPv6() != IsIPv6(raddr.IP) {
+		var err error
+		p, err = newPacketConnWithAddr(raddr, c.connection)
+		if err != nil {
+			return 0, err
+		}
 	}
 	return p.WriteTo(buffer, cm, raddr)
 }
@@ -633,7 +646,16 @@ func (c *UDPConn) writeWithCfg(buffer []byte, cfg UDPWriteCfg) error {
 	if err != nil {
 		return err
 	}
-	if n != len(buffer) {
+	// UDP is datagram-oriented: the kernel either accepts the whole datagram or
+	// reports an error - it never sends "half" a datagram. So only a genuinely
+	// short write (some, but not all, bytes reported) is a real partial write.
+	//
+	// Some write paths/platforms report n=0 with err=nil even though the datagram
+	// was delivered (e.g. (*net.UDPConn).WriteMsgUDP on Windows). Treating that as
+	// a partial write previously broke blockwise transfers (endless loop). Guarding
+	// on `n > 0` makes this resilient to that class of bug regardless of the
+	// underlying write implementation.
+	if n > 0 && n < len(buffer) {
 		return ErrWriteInterrupted
 	}
 

--- a/net/connUDP.go
+++ b/net/connUDP.go
@@ -517,30 +517,33 @@ func (c *UDPConn) writeTo(raddr *net.UDPAddr, cm *ControlMessage, buffer []byte)
 		return c.connection.Write(buffer)
 	}
 
-	// For an unconnected listener we use the ipv4/ipv6 PacketConn.WriteTo wrapper
-	// instead of the raw (*net.UDPConn).WriteMsgUDP. On Windows WriteMsgUDP reports
-	// n=0 even though the datagram is delivered correctly. Historically this made
-	// writeWithCfg treat every server response as a partial write (ErrWriteInterrupted)
-	// and broke blockwise transfers (endless request/response loop). PacketConn.WriteTo
-	// returns the correct number of written bytes on all platforms.
-	//
-	// Note: writeWithCfg also guards against a bogus n=0 result, so the two changes are
-	// defense-in-depth - this wrapper reports the right byte count, and the caller no
-	// longer misinterprets a zero-length report as a partial write.
-	//
-	// Reuse the listener's cached packetConn when its address family matches the
-	// destination. Only on a family mismatch (e.g. a dual-stack socket replying to
-	// the other family) do we build a matching one. This avoids a per-write
-	// allocation and SetControlMessage syscall on the hot response path.
-	p := c.packetConn
-	if p == nil || p.IsIPv6() != IsIPv6(raddr.IP) {
-		var err error
-		p, err = newPacketConnWithAddr(raddr, c.connection)
-		if err != nil {
-			return 0, err
+	var cmb []byte
+	if cm != nil && IsIPv6(raddr.IP) {
+		m := &ipv6.ControlMessage{
+			Src:     cm.Src,
+			IfIndex: cm.IfIndex,
 		}
+		cmb = m.Marshal()
+	} else if cm != nil {
+		m := &ipv4.ControlMessage{
+			Src:     cm.Src,
+			IfIndex: cm.IfIndex,
+		}
+		cmb = m.Marshal()
 	}
-	return p.WriteTo(buffer, cm, raddr)
+
+	// Write through the raw, dual-stack capable socket. This is the portable path:
+	// it correctly sends e.g. to an IPv4 destination from a [::] (dual-stack) socket,
+	// which ipv4.PacketConn.WriteTo rejects on macOS ("sendmsg: invalid argument").
+	//
+	// Caveat: on Windows WriteMsgUDP delivers the datagram but reports n=0, err=nil.
+	// That bogus zero-length report previously broke blockwise transfers (endless
+	// loop). It is now tolerated in writeWithCfg, which treats a zero-length report
+	// as success - a UDP datagram is delivered atomically, so only a genuine
+	// 0 < n < len(buffer) is a real partial write. Keep this portable path and rely
+	// on that guard instead of switching to PacketConn.WriteTo.
+	i, _, err := c.connection.WriteMsgUDP(buffer, cmb, raddr)
+	return i, err
 }
 
 type UDPWriteCfg struct {

--- a/net/connUDP_internal_test.go
+++ b/net/connUDP_internal_test.go
@@ -454,7 +454,10 @@ func TestUDPConnWriteToAddr(t *testing.T) {
 			}
 			network := udp4Network
 			ip := getIfaceAddr(t, iface, true)
-			if IsIPv6(tt.args.src) {
+			// The listen socket family must match the destination address family,
+			// because writeToAddr builds the packetConn from raddr. Derive it from
+			// the source address when set, otherwise from raddr itself.
+			if IsIPv6(tt.args.src) || (tt.args.src == nil && IsIPv6(tt.args.raddr.IP)) {
 				network = udp6Network
 				ip = getIfaceAddr(t, iface, false)
 			}

--- a/net/connUDP_internal_test.go
+++ b/net/connUDP_internal_test.go
@@ -489,10 +489,10 @@ func TestUDPConnWriteToAddr(t *testing.T) {
 //
 // Regression test for the Windows bug where (*net.UDPConn).WriteMsgUDP reports n=0 even
 // though the datagram is delivered, which made writeWithCfg treat every server response as
-// a partial write and broke blockwise transfers. The fix routes writeTo through the
-// ipv4/ipv6 PacketConn.WriteTo wrapper, which returns the correct byte count on all
-// platforms (including Windows). Before the fix this test fails on Windows; after the fix
-// it passes on all platforms.
+// a partial write and broke blockwise transfers. The fix hardens writeWithCfg to treat a
+// zero-length report as success (a UDP datagram is delivered atomically), while keeping the
+// portable, dual-stack capable WriteMsgUDP write path. Before the fix this test fails on
+// Windows; after the fix it passes on all platforms.
 func TestUDPConnUnconnectedWriteReportsFullWrite(t *testing.T) {
 	type netCfg struct {
 		network  string

--- a/net/connUDP_internal_test.go
+++ b/net/connUDP_internal_test.go
@@ -2,6 +2,7 @@ package net
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"runtime"
 	"strconv"
@@ -476,6 +477,82 @@ func TestUDPConnWriteToAddr(t *testing.T) {
 			}
 			require.NoError(t, err)
 		})
+	}
+}
+
+// TestUDPConnUnconnectedWriteReportsFullWrite verifies that writing a datagram from an
+// unconnected server listener (supportsOverrideRemoteAddr == true) reports the full number
+// of written bytes and does not return ErrWriteInterrupted.
+//
+// Regression test for the Windows bug where (*net.UDPConn).WriteMsgUDP reports n=0 even
+// though the datagram is delivered, which made writeWithCfg treat every server response as
+// a partial write and broke blockwise transfers. The fix routes writeTo through the
+// ipv4/ipv6 PacketConn.WriteTo wrapper, which returns the correct byte count on all
+// platforms (including Windows). Before the fix this test fails on Windows; after the fix
+// it passes on all platforms.
+func TestUDPConnUnconnectedWriteReportsFullWrite(t *testing.T) {
+	type netCfg struct {
+		network  string
+		listenIP string
+		dialIP   string
+	}
+	netCfgs := []netCfg{
+		{network: udp4Network, listenIP: "127.0.0.1", dialIP: "127.0.0.1"},
+		{network: udp6Network, listenIP: "::1", dialIP: "::1"},
+	}
+	sizes := []int{1, 256, 512, 1024, 2000}
+
+	for _, nc := range netCfgs {
+		for _, size := range sizes {
+			t.Run(fmt.Sprintf("%s/size=%d", nc.network, size), func(t *testing.T) {
+				server, err := NewListenUDP(nc.network, net.JoinHostPort(nc.listenIP, "0"))
+				if err != nil {
+					t.Skipf("cannot listen on %s: %v", nc.network, err)
+				}
+				defer func() {
+					errC := server.Close()
+					require.NoError(t, errC)
+				}()
+				// Sanity: the server listener must be unconnected so that the
+				// supportsOverrideRemoteAddr write path (the buggy one) is exercised.
+				require.True(t, supportsOverrideRemoteAddr(server.connection))
+
+				serverAddr, ok := server.LocalAddr().(*net.UDPAddr)
+				require.True(t, ok)
+				// Use the loopback dial IP instead of the (possibly unspecified) listen IP.
+				dialAddr := &net.UDPAddr{IP: net.ParseIP(nc.dialIP), Port: serverAddr.Port}
+
+				client, err := net.DialUDP(nc.network, nil, dialAddr)
+				require.NoError(t, err)
+				defer func() {
+					errC := client.Close()
+					require.NoError(t, errC)
+				}()
+
+				clientAddr, ok := client.LocalAddr().(*net.UDPAddr)
+				require.True(t, ok)
+
+				payload := make([]byte, size)
+				for i := range payload {
+					payload[i] = byte(i % 251)
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+				defer cancel()
+
+				// This is the assertion that fails on Windows before the fix: writeTo
+				// returns n=0 -> writeWithCfg returns ErrWriteInterrupted.
+				err = server.WriteWithContext(ctx, clientAddr, payload)
+				require.NoError(t, err)
+
+				errR := client.SetReadDeadline(time.Now().Add(time.Second * 2))
+				require.NoError(t, errR)
+				got := make([]byte, size+16)
+				n, errR := client.Read(got)
+				require.NoError(t, errR)
+				require.Equal(t, payload, got[:n])
+			})
+		}
 	}
 }
 

--- a/net/connUDP_internal_test.go
+++ b/net/connUDP_internal_test.go
@@ -483,6 +483,77 @@ func TestUDPConnWriteToAddr(t *testing.T) {
 	}
 }
 
+// TestUDPConnDualStackWriteDelivers verifies that a server response from a dual-stack
+// ("udp" / [::]) listener to an IPv4 client is accepted AND actually delivered, on every
+// platform.
+//
+// This is the combination that needs explicit coverage:
+//   - Windows: the underlying WriteMsgUDP reports n=0 (must still count as success via the
+//     writeWithCfg guard), and
+//   - macOS: ipv4.PacketConn.WriteTo cannot send to an IPv4 destination from a [::] socket
+//     ("sendmsg: invalid argument"), which is why the portable WriteMsgUDP path is kept.
+//
+// The existing TestUDPConnWriteWithContext/"send to v4 from v6 socket" only asserts the
+// absence of an error; this test additionally asserts the datagram is received.
+func TestUDPConnDualStackWriteDelivers(t *testing.T) {
+	// Dual-stack listener (IPv6 socket that also accepts IPv4 via v4-mapped addresses).
+	server, err := NewListenUDP(udpNetwork, "[::]:0")
+	if err != nil {
+		t.Skipf("cannot create dual-stack listener: %v", err)
+	}
+	defer func() {
+		errC := server.Close()
+		require.NoError(t, errC)
+	}()
+	require.True(t, supportsOverrideRemoteAddr(server.connection))
+	// Confirm we really exercise the v4-from-v6 path: the listener socket is IPv6.
+	require.True(t, server.packetConn.IsIPv6(), "listener should be a dual-stack IPv6 socket")
+
+	serverAddr, ok := server.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+
+	// IPv4 client talking to the dual-stack server over loopback.
+	client, err := net.DialUDP(udp4Network, nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: serverAddr.Port})
+	if err != nil {
+		t.Skipf("cannot dial IPv4 to dual-stack listener: %v", err)
+	}
+	defer func() {
+		errC := client.Close()
+		require.NoError(t, errC)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	// The client pings first so the server learns the remote address in whatever form the
+	// OS reports it (mirrors a real server reply flow).
+	_, err = client.Write([]byte("ping"))
+	require.NoError(t, err)
+
+	buf := make([]byte, 64)
+	var raddr *net.UDPAddr
+	_, err = server.ReadWithOptions(buf, WithContext(ctx), WithGetRemoteAddr(&raddr))
+	require.NoError(t, err)
+	require.NotNil(t, raddr)
+
+	payload := make([]byte, 1500)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+
+	// The server reply path must succeed (no bogus ErrWriteInterrupted on Windows) and the
+	// datagram must actually arrive (no silent drop / family mismatch on macOS).
+	err = server.WriteWithContext(ctx, raddr, payload)
+	require.NoError(t, err)
+
+	errR := client.SetReadDeadline(time.Now().Add(time.Second * 2))
+	require.NoError(t, errR)
+	got := make([]byte, len(payload)+16)
+	n, errR := client.Read(got)
+	require.NoError(t, errR)
+	require.Equal(t, payload, got[:n])
+}
+
 // TestUDPConnUnconnectedWriteReportsFullWrite verifies that writing a datagram from an
 // unconnected server listener (supportsOverrideRemoteAddr == true) reports the full number
 // of written bytes and does not return ErrWriteInterrupted.

--- a/net/writeMsgUDP_windows_test.go
+++ b/net/writeMsgUDP_windows_test.go
@@ -1,0 +1,86 @@
+//go:build windows
+
+package net
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/ipv4"
+)
+
+// TestWindowsWriteMsgUDPReportingBehavior documents and pins the Windows-specific UDP write
+// behavior that motivated routing writeTo through the ipv4/ipv6 PacketConn.WriteTo wrapper.
+//
+// Background: on Windows (observed with go1.26.4) (*net.UDPConn).WriteMsgUDP delivers the
+// datagram correctly but reports n=0, err=nil. go-coap previously used WriteMsgUDP for the
+// unconnected server-listener path, so writeWithCfg treated every server response as a
+// partial write (ErrWriteInterrupted) and blockwise transfers looped forever.
+//
+// This test acts as an early-warning regression guard:
+//   - It does NOT hard-fail on the stdlib WriteMsgUDP behavior (a future Go fix may change
+//     n from 0 to the real length). Instead it logs what WriteMsgUDP reports so a change is
+//     visible in test output.
+//   - It DOES hard-assert that ipv4.PacketConn.WriteTo and go-coap's writeTo report the full
+//     byte count on Windows. These are the guarantees the fix relies on; if they regress the
+//     test fails.
+func TestWindowsWriteMsgUDPReportingBehavior(t *testing.T) {
+	server, err := NewListenUDP(udp4Network, "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() {
+		errC := server.Close()
+		require.NoError(t, errC)
+	}()
+	require.True(t, supportsOverrideRemoteAddr(server.connection))
+
+	serverAddr, ok := server.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+
+	client, err := net.DialUDP(udp4Network, nil, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: serverAddr.Port})
+	require.NoError(t, err)
+	defer func() {
+		errC := client.Close()
+		require.NoError(t, errC)
+	}()
+	clientAddr, ok := client.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+
+	sizes := []int{300, 1024, 1100, 2000}
+	for _, size := range sizes {
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = byte(i % 251)
+		}
+
+		// 1) Raw stdlib WriteMsgUDP: only logged, not asserted (may report n=0 on Windows).
+		rawN, _, errRaw := server.connection.WriteMsgUDP(payload, nil, clientAddr)
+		require.NoError(t, errRaw)
+		drainOne(t, client, size)
+		t.Logf("size=%4d  WriteMsgUDP reported n=%d (Windows historically reports 0 despite delivery)", size, rawN)
+
+		// 2) ipv4.PacketConn.WriteTo: must report the full length on Windows (the working path).
+		p := ipv4.NewPacketConn(server.connection)
+		wtN, errWt := p.WriteTo(payload, &ipv4.ControlMessage{Src: net.IPv4(127, 0, 0, 1)}, clientAddr)
+		require.NoError(t, errWt)
+		require.Equal(t, size, wtN, "ipv4.PacketConn.WriteTo must report full length on Windows")
+		drainOne(t, client, size)
+
+		// 3) go-coap writeTo (the fixed path): must report the full length on Windows.
+		gcN, errGc := server.writeTo(clientAddr, nil, payload)
+		require.NoError(t, errGc)
+		require.Equal(t, size, gcN, "writeTo must report full length on Windows after the fix")
+		drainOne(t, client, size)
+	}
+}
+
+func drainOne(t *testing.T, client *net.UDPConn, size int) {
+	t.Helper()
+	errR := client.SetReadDeadline(time.Now().Add(time.Second))
+	require.NoError(t, errR)
+	buf := make([]byte, size+16)
+	n, err := client.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, size, n)
+}

--- a/net/writeMsgUDP_windows_test.go
+++ b/net/writeMsgUDP_windows_test.go
@@ -3,6 +3,7 @@
 package net
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -12,20 +13,22 @@ import (
 )
 
 // TestWindowsWriteMsgUDPReportingBehavior documents and pins the Windows-specific UDP write
-// behavior that motivated routing writeTo through the ipv4/ipv6 PacketConn.WriteTo wrapper.
+// behavior that motivated the blockwise fix.
 //
 // Background: on Windows (observed with go1.26.4) (*net.UDPConn).WriteMsgUDP delivers the
-// datagram correctly but reports n=0, err=nil. go-coap previously used WriteMsgUDP for the
-// unconnected server-listener path, so writeWithCfg treated every server response as a
-// partial write (ErrWriteInterrupted) and blockwise transfers looped forever.
+// datagram correctly but reports n=0, err=nil. go-coap's unconnected server-listener path
+// uses WriteMsgUDP, so writeWithCfg previously treated every server response as a partial
+// write (ErrWriteInterrupted) and blockwise transfers looped forever.
 //
-// This test acts as an early-warning regression guard:
-//   - It does NOT hard-fail on the stdlib WriteMsgUDP behavior (a future Go fix may change
-//     n from 0 to the real length). Instead it logs what WriteMsgUDP reports so a change is
-//     visible in test output.
-//   - It DOES hard-assert that ipv4.PacketConn.WriteTo and go-coap's writeTo report the full
-//     byte count on Windows. These are the guarantees the fix relies on; if they regress the
-//     test fails.
+// The fix keeps the portable WriteMsgUDP path (it is dual-stack capable, unlike
+// ipv4.PacketConn.WriteTo which fails on macOS) and instead hardens writeWithCfg to treat a
+// zero-length report as success. This test acts as an early-warning regression guard:
+//   - It does NOT hard-fail on the raw stdlib WriteMsgUDP behavior (a future Go fix may
+//     change n from 0 to the real length). Instead it logs what WriteMsgUDP reports so a
+//     change is visible in test output.
+//   - It DOES hard-assert that the public write path (WriteWithContext / writeWithCfg)
+//     succeeds and the datagram is delivered, even though the raw WriteMsgUDP reports n=0.
+//     This is the guarantee the fix relies on; if it regresses the test fails.
 func TestWindowsWriteMsgUDPReportingBehavior(t *testing.T) {
 	server, err := NewListenUDP(udp4Network, "127.0.0.1:0")
 	require.NoError(t, err)
@@ -54,23 +57,30 @@ func TestWindowsWriteMsgUDPReportingBehavior(t *testing.T) {
 			payload[i] = byte(i % 251)
 		}
 
-		// 1) Raw stdlib WriteMsgUDP: only logged, not asserted (may report n=0 on Windows).
+		// 1) Raw stdlib WriteMsgUDP: only logged, not asserted. On Windows it historically
+		//    reports n=0 even though the datagram is delivered. A change here (e.g. a future
+		//    Go fix) becomes visible in the test output without failing the suite.
 		rawN, _, errRaw := server.connection.WriteMsgUDP(payload, nil, clientAddr)
 		require.NoError(t, errRaw)
 		drainOne(t, client, size)
-		t.Logf("size=%4d  WriteMsgUDP reported n=%d (Windows historically reports 0 despite delivery)", size, rawN)
+		t.Logf("size=%4d  raw WriteMsgUDP reported n=%d (Windows historically reports 0 despite delivery)", size, rawN)
 
-		// 2) ipv4.PacketConn.WriteTo: must report the full length on Windows (the working path).
+		// 2) Informational: ipv4.PacketConn.WriteTo reports the full length on Windows. We do
+		//    NOT use it as the write path because it is not dual-stack capable on macOS, but it
+		//    illustrates that the n=0 quirk is specific to WriteMsgUDP.
 		p := ipv4.NewPacketConn(server.connection)
 		wtN, errWt := p.WriteTo(payload, &ipv4.ControlMessage{Src: net.IPv4(127, 0, 0, 1)}, clientAddr)
 		require.NoError(t, errWt)
 		require.Equal(t, size, wtN, "ipv4.PacketConn.WriteTo must report full length on Windows")
 		drainOne(t, client, size)
 
-		// 3) go-coap writeTo (the fixed path): must report the full length on Windows.
-		gcN, errGc := server.writeTo(clientAddr, nil, payload)
-		require.NoError(t, errGc)
-		require.Equal(t, size, gcN, "writeTo must report full length on Windows after the fix")
+		// 3) The real guarantee: the public write path must succeed and deliver the datagram
+		//    on Windows even though the underlying WriteMsgUDP reports n=0. This is what the
+		//    writeWithCfg hardening ensures.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		errPub := server.WriteWithContext(ctx, clientAddr, payload)
+		cancel()
+		require.NoError(t, errPub, "WriteWithContext must not return ErrWriteInterrupted despite raw n=0")
 		drainOne(t, client, size)
 	}
 }

--- a/udp/blockwise_test.go
+++ b/udp/blockwise_test.go
@@ -1,0 +1,101 @@
+package udp_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/plgd-dev/go-coap/v3/message/codes"
+	"github.com/plgd-dev/go-coap/v3/message/pool"
+	coapNet "github.com/plgd-dev/go-coap/v3/net"
+	"github.com/plgd-dev/go-coap/v3/net/blockwise"
+	"github.com/plgd-dev/go-coap/v3/net/responsewriter"
+	"github.com/plgd-dev/go-coap/v3/options"
+	"github.com/plgd-dev/go-coap/v3/udp"
+	"github.com/plgd-dev/go-coap/v3/udp/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+// TestServerBlockwiseLargeResponse is an end-to-end regression test for the Windows
+// WriteMsgUDP n=0 bug. A response larger than a single block forces a Block2 transfer.
+//
+// Before the fix, on Windows the server saw a bogus ErrWriteInterrupted after sending the
+// first block, aborted the blockwise session, and re-ran the handler for every follow-up
+// block request, looping forever and leaking memory. The test would then hang until the
+// context timeout.
+//
+// After the fix the transfer completes, the full payload is received, and the handler is
+// invoked only a small, bounded number of times (no endless re-invocation).
+func TestServerBlockwiseLargeResponse(t *testing.T) {
+	const payloadSize = 10 * 1024
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+
+	var handlerCalls atomic.Int32
+
+	ld, err := coapNet.NewListenUDP("udp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() {
+		errC := ld.Close()
+		require.NoError(t, errC)
+	}()
+
+	sd := udp.NewServer(
+		options.WithBlockwise(true, blockwise.SZX1024, time.Second*5),
+		options.WithHandlerFunc(func(w *responsewriter.ResponseWriter[*client.Conn], _ *pool.Message) {
+			handlerCalls.Inc()
+			errH := w.SetResponse(codes.Content, message.TextPlain, bytes.NewReader(payload))
+			assert.NoError(t, errH)
+		}),
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errS := sd.Serve(ld)
+		assert.NoError(t, errS)
+	}()
+	defer func() {
+		sd.Stop()
+		wg.Wait()
+	}()
+
+	cc, err := udp.Dial(
+		ld.LocalAddr().String(),
+		options.WithBlockwise(true, blockwise.SZX1024, time.Second*5),
+	)
+	require.NoError(t, err)
+	defer func() {
+		errC := cc.Close()
+		require.NoError(t, errC)
+		<-cc.Done()
+	}()
+
+	// The timeout guards against the endless loop: if the bug is present, Get never
+	// completes and returns a deadline-exceeded error instead of hanging the suite.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	resp, err := cc.Get(ctx, "/test")
+	require.NoError(t, err)
+	require.Equal(t, codes.Content, resp.Code())
+
+	body, err := io.ReadAll(resp.Body())
+	require.NoError(t, err)
+	require.Equal(t, payload, body)
+
+	// The handler must be called once (allow a small margin for a possible retransmit),
+	// not re-invoked for every block request as happened during the loop.
+	calls := handlerCalls.Load()
+	require.GreaterOrEqual(t, calls, int32(1))
+	require.LessOrEqual(t, calls, int32(3))
+}


### PR DESCRIPTION
fixes #659 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP multicast write error aggregation and preserved consistent success/failure return behavior across interfaces/sources.
  * Refined short-write interruption handling to flag only genuine partial writes.
  * Updated portable UDP write behavior documentation and aligned Windows UDP write-reporting expectations to ensure full datagram counts.
* **Tests**
  * Added UDP regression tests covering IPv4/IPv6 delivery, dual-stack listeners, and unconnected server write behavior.
  * Added Windows-only checks for `WriteMsgUDP`-reported byte counts.
  * Added a UDP CoAP blockwise end-to-end regression test for large responses to prevent repeated handler invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->