### PR TITLE
dtls: run handshake before OnNewConn

### DIFF
--- a/dtls/server/config.go
+++ b/dtls/server/config.go
@@ -43,6 +43,7 @@ var DefaultConfig = func() Config {
 		TransmissionNStart:             1,
 		TransmissionAcknowledgeTimeout: time.Second * 2,
 		TransmissionMaxRetransmit:      4,
+		HandshakeTimeout:               30 * time.Second,
 		GetMID:                         message.GetMID,
 		MTU:                            udpClient.DefaultMTU,
 	}
@@ -64,5 +65,6 @@ type Config struct {
 	TransmissionNStart             uint32
 	TransmissionAcknowledgeTimeout time.Duration
 	TransmissionMaxRetransmit      uint32
+	HandshakeTimeout               time.Duration
 	MTU                            uint16
 }

--- a/dtls/server/server.go
+++ b/dtls/server/server.go
@@ -131,7 +131,9 @@ func (s *Server) checkAcceptError(err error) bool {
 func (s *Server) serveConnection(connections *connections.Connections, rw net.Conn) {
 	if h, ok := rw.(handshakeWithContext); ok {
 		handshakeCtx := s.ctx
-		cancel := func() {}
+		cancel := func() {
+			// do nothing by default
+		}
 		if s.cfg.HandshakeTimeout > 0 {
 			handshakeCtx, cancel = context.WithTimeout(s.ctx, s.cfg.HandshakeTimeout)
 		}

--- a/dtls/server/server.go
+++ b/dtls/server/server.go
@@ -17,6 +17,10 @@ import (
 	udpClient "github.com/plgd-dev/go-coap/v3/udp/client"
 )
 
+type handshakeWithContext interface {
+	HandshakeContext(ctx context.Context) error
+}
+
 // Listener defined used by coap
 type Listener interface {
 	Close() error
@@ -125,6 +129,21 @@ func (s *Server) checkAcceptError(err error) bool {
 }
 
 func (s *Server) serveConnection(connections *connections.Connections, rw net.Conn) {
+	if h, ok := rw.(handshakeWithContext); ok {
+		handshakeCtx := s.ctx
+		cancel := func() {}
+		if s.cfg.HandshakeTimeout > 0 {
+			handshakeCtx, cancel = context.WithTimeout(s.ctx, s.cfg.HandshakeTimeout)
+		}
+		err := h.HandshakeContext(handshakeCtx)
+		cancel()
+		if err != nil {
+			s.cfg.Errors(fmt.Errorf("%v: handshake failed: %w", rw.RemoteAddr(), err))
+			_ = rw.Close()
+			return
+		}
+	}
+
 	inactivityMonitor := s.cfg.CreateInactivityMonitor()
 	requestMonitor := s.cfg.RequestMonitor
 	dtlsConn := coapNet.NewConn(rw)

--- a/dtls/server_test.go
+++ b/dtls/server_test.go
@@ -408,13 +408,23 @@ func TestServerOnNewConnReadsConnectionStateWithoutManualHandshake(t *testing.T)
 
 	onNewConn := func(cc *client.Conn) {
 		dtlsConn, ok := cc.NetConn().(*piondtls.Conn)
-		assert.True(t, ok)
+		if !assert.True(t, ok) {
+			return
+		}
 		// Handshake was already performed by the server before OnNewConn is called,
 		// so ConnectionState() must succeed without a manual HandshakeContext call.
 		state, ok := dtlsConn.ConnectionState()
-		assert.True(t, ok)
+		if !assert.True(t, ok) {
+			return
+		}
+		if !assert.NotEmpty(t, state.PeerCertificates) {
+			return
+		}
 		clientCert, errP := x509.ParseCertificate(state.PeerCertificates[0])
-		assert.NoError(t, errP) //nolint:testifylint
+		if !assert.NoError(t, errP) { //nolint:testifylint
+			return
+		}
+		cc.SetContextValue("client-cert", clientCert)
 		cc.SetContextValue("client-cert", clientCert)
 	}
 	handle := func(w *responsewriter.ResponseWriter[*client.Conn], r *pool.Message) {

--- a/dtls/server_test.go
+++ b/dtls/server_test.go
@@ -389,6 +389,146 @@ func createDTLSOptionsConfig() (serverOpts coapNet.DTLSServerOptions, clientOpts
 	return
 }
 
+// TestServerOnNewConnReadsConnectionStateWithoutManualHandshake verifies that
+// the server completes the DTLS handshake before invoking OnNewConn, so the
+// callback can safely call dtlsConn.ConnectionState() without needing to call
+// HandshakeContext itself.
+func TestServerOnNewConnReadsConnectionStateWithoutManualHandshake(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+	serverCfg, clientCfg, clientSerial, err := createDTLSConfig()
+	require.NoError(t, err)
+
+	ld, err := coapNet.NewDTLSListener("udp4", "", serverCfg)
+	require.NoError(t, err)
+	defer func() {
+		errC := ld.Close()
+		require.NoError(t, errC)
+	}()
+
+	onNewConn := func(cc *client.Conn) {
+		dtlsConn, ok := cc.NetConn().(*piondtls.Conn)
+		assert.True(t, ok)
+		// Handshake was already performed by the server before OnNewConn is called,
+		// so ConnectionState() must succeed without a manual HandshakeContext call.
+		state, ok := dtlsConn.ConnectionState()
+		assert.True(t, ok)
+		clientCert, errP := x509.ParseCertificate(state.PeerCertificates[0])
+		assert.NoError(t, errP) //nolint:testifylint
+		cc.SetContextValue("client-cert", clientCert)
+	}
+	handle := func(w *responsewriter.ResponseWriter[*client.Conn], r *pool.Message) {
+		clientCert, _ := r.Context().Value("client-cert").(*x509.Certificate)
+		require.NotNil(t, clientCert)
+		assert.Equal(t, clientSerial, clientCert.SerialNumber)
+		errH := w.SetResponse(codes.Content, message.TextPlain, bytes.NewReader([]byte("done")))
+		assert.NoError(t, errH)
+	}
+
+	sd := dtls.NewServer(options.WithHandlerFunc(handle), options.WithOnNewConn(onNewConn))
+	var wg sync.WaitGroup
+	defer func() {
+		sd.Stop()
+		wg.Wait()
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errS := sd.Serve(ld)
+		assert.NoError(t, errS)
+	}()
+
+	cc, err := dtls.Dial(ld.Addr().String(), clientCfg)
+	require.NoError(t, err)
+	defer func() {
+		errC := cc.Close()
+		require.NoError(t, errC)
+		<-cc.Done()
+	}()
+
+	_, err = cc.Get(ctx, "/")
+	require.NoError(t, err)
+}
+
+// stalledHandshakeConn wraps a net.Conn and adds a HandshakeContext that blocks
+// until the provided context is cancelled, simulating a stalled DTLS handshake.
+type stalledHandshakeConn struct {
+	net.Conn
+}
+
+func (c *stalledHandshakeConn) HandshakeContext(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// singleConnListener is a minimal Listener that returns one conn on the first
+// AcceptWithContext call and then blocks until its own context is cancelled.
+type singleConnListener struct {
+	ch chan net.Conn
+}
+
+func newSingleConnListener(conn net.Conn) *singleConnListener {
+	l := &singleConnListener{ch: make(chan net.Conn, 1)}
+	l.ch <- conn
+	return l
+}
+
+func (l *singleConnListener) AcceptWithContext(ctx context.Context) (net.Conn, error) {
+	select {
+	case conn := <-l.ch:
+		return conn, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (l *singleConnListener) Close() error { return nil }
+
+// TestServerHandshakeTimeout verifies that WithDTLSHandshakeTimeout causes
+// stalled DTLS handshakes to be abandoned and reported via the error callback.
+//
+// pion/dtls completes the handshake inside Accept(), so we use a synthetic
+// Listener that returns a connection whose HandshakeContext blocks until the
+// timeout fires, properly exercising the timeout path in serveConnection.
+func TestServerHandshakeTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+
+	// The stalled conn blocks HandshakeContext until the context deadline.
+	clientSide, serverSide := net.Pipe()
+	defer func() { _ = clientSide.Close() }()
+	connListener := newSingleConnListener(&stalledHandshakeConn{serverSide})
+
+	errCh := make(chan error, 1)
+	sd := dtls.NewServer(
+		options.WithDTLSHandshakeTimeout(time.Millisecond),
+		options.WithErrors(func(err error) {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}),
+	)
+	var serverWg sync.WaitGroup
+	defer func() {
+		sd.Stop()
+		serverWg.Wait()
+	}()
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		errS := sd.Serve(connListener)
+		assert.NoError(t, errS)
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "handshake failed")
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for handshake error callback")
+	}
+}
+
 // TestServerCleanUpConnsWithOptions mirrors TestServerCleanUpConns but uses
 // the generic NewDTLSListener and Dial API.
 func TestServerCleanUpConnsWithOptions(t *testing.T) {

--- a/options/udpOptions.go
+++ b/options/udpOptions.go
@@ -68,3 +68,18 @@ func WithMTU(mtu uint16) MTUOpt {
 		mtu: mtu,
 	}
 }
+
+// DTLSHandshakeTimeoutOpt configures server-side DTLS handshake timeout.
+type DTLSHandshakeTimeoutOpt struct {
+	timeout time.Duration
+}
+
+func (o DTLSHandshakeTimeoutOpt) DTLSServerApply(cfg *dtlsServer.Config) {
+	cfg.HandshakeTimeout = o.timeout
+}
+
+// WithDTLSHandshakeTimeout sets timeout for DTLS handshake performed before OnNewConn callback.
+// Set to 0 or a negative value to disable timeout and use server context cancellation only.
+func WithDTLSHandshakeTimeout(timeout time.Duration) DTLSHandshakeTimeoutOpt {
+	return DTLSHandshakeTimeoutOpt{timeout: timeout}
+}

--- a/options/udpOptions_test.go
+++ b/options/udpOptions_test.go
@@ -34,6 +34,7 @@ func TestDTLSServerApply(t *testing.T) {
 	opt := []dtlsServer.Option{
 		options.WithTransmission(10, time.Second, 5),
 		options.WithMTU(1500),
+		options.WithDTLSHandshakeTimeout(12 * time.Second),
 	}
 	for _, o := range opt {
 		o.DTLSServerApply(&cfg)
@@ -44,6 +45,8 @@ func TestDTLSServerApply(t *testing.T) {
 	require.Equal(t, uint32(5), cfg.TransmissionMaxRetransmit)
 	// WithMTU
 	require.Equal(t, uint16(1500), cfg.MTU)
+	// WithDTLSHandshakeTimeout
+	require.Equal(t, 12*time.Second, cfg.HandshakeTimeout)
 }
 
 func TestUDPClientApply(t *testing.T) {


### PR DESCRIPTION
Ensure DTLS handshake completes before invoking OnNewConn so callback code can safely read DTLS connection state.

## Changes Made

- **Pre-handshake in `serveConnection`**: The server now calls `HandshakeContext` on the accepted connection before invoking `OnNewConn`, so callbacks can safely call `dtlsConn.ConnectionState()` without needing to manually trigger the handshake themselves.
- **`WithDTLSHandshakeTimeout` option**: New server option to bound the time allowed for the server-side DTLS handshake. Set to `0` or a negative value to disable the timeout and rely solely on server context cancellation.

## Tests Added

- **`TestServerOnNewConnReadsConnectionStateWithoutManualHandshake`**: Verifies that `OnNewConn` can call `dtlsConn.ConnectionState()` directly (without a manual `HandshakeContext` call) and receive a valid peer certificate, confirming the handshake is complete before the callback fires.
- **`TestServerHandshakeTimeout`**: Verifies that `WithDTLSHandshakeTimeout` causes stalled handshakes to be abandoned and reported via the error callback. Uses a synthetic listener with a connection whose `HandshakeContext` blocks until the deadline, since pion/dtls completes the handshake inside `Accept()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DTLS handshake timeout support via `WithDTLSHandshakeTimeout(timeout)`, with a default handshake timeout of 30 seconds.
  * If configured, the server performs the DTLS handshake before invoking `WithOnNewConn` and makes handshake context available for connection setup.
  * Setting `timeout ≤ 0` disables the timeout (uses server context cancellation instead).
* **Bug Fixes**
  * Failed DTLS handshakes now trigger `WithErrors`, close the connection, and stop further setup for that peer.
* **Tests**
  * Added coverage for reading connection state in `WithOnNewConn` and for handshake timeout error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->