### PR TITLE
udp/server: fix wildcard NewConn response routing

### DIFF
--- a/udp/server/server.go
+++ b/udp/server/server.go
@@ -279,7 +279,30 @@ func getConnKey(raddr, laddr *net.UDPAddr) string {
 		normalizedLocalAddr.IP = nil
 		normalizedLocalAddr.Zone = ""
 	}
+	if len(normalizedLocalAddr.IP) > 0 && normalizedLocalAddr.IP.IsUnspecified() {
+		// Wildcard listener addresses (0.0.0.0 / ::) are placeholders and do not identify
+		// a concrete destination address selected by the kernel for outgoing packets.
+		normalizedLocalAddr.IP = nil
+		normalizedLocalAddr.Zone = ""
+	}
 	return raddr.String() + "-" + normalizedLocalAddr.String()
+}
+
+func localAddrCanFallbackToWildcard(laddr *net.UDPAddr) bool {
+	if laddr == nil || len(laddr.IP) == 0 {
+		return false
+	}
+	if laddr.IP.IsMulticast() || laddr.IP.IsUnspecified() {
+		return false
+	}
+	return true
+}
+
+func toWildcardLocalAddr(laddr *net.UDPAddr) *net.UDPAddr {
+	wildcard := *laddr
+	wildcard.IP = nil
+	wildcard.Zone = ""
+	return &wildcard
 }
 
 func (s *Server) getOrCreateConn(udpConn *coapNet.UDPConn, raddr *net.UDPAddr, laddr *net.UDPAddr) (cc *client.Conn, created bool) {
@@ -290,6 +313,16 @@ func (s *Server) getOrCreateConn(udpConn *coapNet.UDPConn, raddr *net.UDPAddr, l
 
 	if cc != nil {
 		return cc, false
+	}
+
+	// When a client connection is created via NewConn() on a wildcard-bound listener,
+	// it is keyed by wildcard local address. Incoming datagrams can carry the concrete
+	// destination address in control messages, so fallback keeps these packets on the
+	// same conn instead of creating a second server-side conn.
+	if localAddrCanFallbackToWildcard(laddr) {
+		if cc = s.conns[getConnKey(raddr, toWildcardLocalAddr(laddr))]; cc != nil {
+			return cc, false
+		}
 	}
 
 	createBlockWise := func(*client.Conn) *blockwise.BlockWise[*client.Conn] {
@@ -417,6 +450,7 @@ func (s *Server) getConn(l *coapNet.UDPConn, raddr *net.UDPAddr, laddr *net.UDPA
 //
 // Optional laddr may be used to pin a concrete local address when the listener is bound to a wildcard address.
 // If laddr is omitted or nil, listener's local address is used.
+// For wildcard listeners, incoming packets addressed to concrete local IPs are matched to this conn.
 func (s *Server) NewConn(addr *net.UDPAddr, laddr ...*net.UDPAddr) (*client.Conn, error) {
 	if len(laddr) > 1 {
 		return nil, fmt.Errorf("invalid number of local addresses: %d", len(laddr))

--- a/udp/server/server_key_test.go
+++ b/udp/server/server_key_test.go
@@ -24,3 +24,13 @@ func TestGetConnKeyKeepsUnicastLocalAddressDistinct(t *testing.T) {
 
 	require.NotEqual(t, getConnKey(raddr, laddrA), getConnKey(raddr, laddrB))
 }
+
+func TestGetConnKeyNormalizesUnspecifiedLocalAddress(t *testing.T) {
+	raddr := &net.UDPAddr{IP: net.ParseIP("192.0.2.1"), Port: 56830}
+	unspecifiedV4 := &net.UDPAddr{IP: net.IPv4zero, Port: 5683}
+	unspecifiedV6 := &net.UDPAddr{IP: net.IPv6zero, Port: 5683}
+	normalized := &net.UDPAddr{Port: 5683}
+
+	require.Equal(t, getConnKey(raddr, unspecifiedV4), getConnKey(raddr, normalized))
+	require.Equal(t, getConnKey(raddr, unspecifiedV6), getConnKey(raddr, normalized))
+}

--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -487,6 +487,97 @@ func TestServerNewClient(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestServerNewConnWildcardBindRoutesResponseToClient(t *testing.T) {
+	newServer := func(l *coapNet.UDPConn, opts ...server.Option) (*server.Server, func()) {
+		var wg sync.WaitGroup
+		s := udp.NewServer(opts...)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errS := s.Serve(l)
+			assert.NoError(t, errS)
+		}()
+		return s, func() {
+			s.Stop()
+			wg.Wait()
+		}
+	}
+
+	listenerA, err := coapNet.NewListenUDP("udp4", "0.0.0.0:0")
+	require.NoError(t, err)
+	defer func() {
+		errC := listenerA.Close()
+		require.NoError(t, errC)
+	}()
+
+	listenerB, err := coapNet.NewListenUDP("udp4", "0.0.0.0:0")
+	require.NoError(t, err)
+	defer func() {
+		errC := listenerB.Close()
+		require.NoError(t, errC)
+	}()
+
+	const putPath = "/somepath"
+
+	var defaultHits atomic.Int32
+	routerA := mux.NewRouter()
+	routerA.DefaultHandleFunc(func(_ mux.ResponseWriter, req *mux.Message) {
+		defaultHits.Inc()
+		_, _ = req.ReadBody()
+	})
+
+	routerB := mux.NewRouter()
+	routerB.HandleFunc(putPath, func(w mux.ResponseWriter, r *mux.Message) {
+		if r.Code() != codes.PUT {
+			_ = w.SetResponse(codes.MethodNotAllowed, message.TextPlain, bytes.NewReader([]byte("method not allowed")))
+			return
+		}
+		body, errR := r.ReadBody()
+		if errR != nil {
+			_ = w.SetResponse(codes.BadRequest, message.TextPlain, bytes.NewReader([]byte(errR.Error())))
+			return
+		}
+		_ = w.SetResponse(codes.Created, message.TextPlain, bytes.NewReader(body))
+	})
+
+	serverA, shutdownA := newServer(listenerA, options.WithMux(routerA))
+	defer shutdownA()
+
+	_, shutdownB := newServer(listenerB, options.WithMux(routerB))
+	defer shutdownB()
+
+	target := &net.UDPAddr{IP: net.ParseIP("127.0.0.1").To4(), Port: listenerB.LocalAddr().(*net.UDPAddr).Port}
+
+	var cc *client.Conn
+	require.Eventually(t, func() bool {
+		ccCandidate, errN := serverA.NewConn(target)
+		if errN != nil {
+			return false
+		}
+		cc = ccCandidate
+		return true
+	}, time.Second, 10*time.Millisecond)
+	require.NotNil(t, cc)
+	defer func() {
+		errC := cc.Close()
+		require.NoError(t, errC)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	resp, err := cc.Put(ctx, putPath, message.TextPlain, bytes.NewReader([]byte("payload")))
+	require.NoError(t, err)
+	defer cc.ReleaseMessage(resp)
+	require.Equal(t, codes.Created, resp.Code())
+
+	_, err = resp.ReadBody()
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, int32(0), defaultHits.Load())
+}
+
 func TestCheckForLossOrder(t *testing.T) {
 	ld, err := coapNet.NewListenUDP("udp4", "")
 	require.NoError(t, err)

--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -490,16 +490,17 @@ func TestServerNewClient(t *testing.T) {
 func TestServerNewConnWildcardBindRoutesResponseToClient(t *testing.T) {
 	newServer := func(l *coapNet.UDPConn, opts ...server.Option) (*server.Server, func()) {
 		var wg sync.WaitGroup
+		var serveErr error
 		s := udp.NewServer(opts...)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			errS := s.Serve(l)
-			assert.NoError(t, errS)
+			serveErr = s.Serve(l)
 		}()
 		return s, func() {
 			s.Stop()
 			wg.Wait()
+			assert.NoError(t, serveErr)
 		}
 	}
 
@@ -574,8 +575,7 @@ func TestServerNewConnWildcardBindRoutesResponseToClient(t *testing.T) {
 	_, err = resp.ReadBody()
 	require.NoError(t, err)
 
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, int32(0), defaultHits.Load())
+	assert.Never(t, func() bool { return defaultHits.Load() != 0 }, 100*time.Millisecond, 10*time.Millisecond)
 }
 
 func TestCheckForLossOrder(t *testing.T) {


### PR DESCRIPTION
Fixes #658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP connection reuse for wildcard-bound listeners by normalizing unspecified local addresses.
  * Ensured datagrams targeting concrete local IPs on wildcard listeners are routed through the correct server-side connection, so responses reach the intended client.
* **Tests**
  * Added unit tests covering connection key normalization and verified wildcard listener routing to the correct client-side handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->