### PR TITLE
fix: reject unknown critical options

### DIFF
--- a/net/client/criticalOptions.go
+++ b/net/client/criticalOptions.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/plgd-dev/go-coap/v3/message"
+)
+
+// GetUnknownCriticalOptions returns unique unknown critical option IDs in option-order.
+func GetUnknownCriticalOptions(options message.Options) []message.OptionID {
+	unknownCriticalOpts := make([]message.OptionID, 0, 4)
+	var lastUnknownCriticalOpt message.OptionID
+	for _, opt := range options {
+		if opt.ID%2 == 0 {
+			continue
+		}
+		if _, ok := message.CoapOptionDefs[opt.ID]; ok {
+			continue
+		}
+		if len(unknownCriticalOpts) > 0 && opt.ID == lastUnknownCriticalOpt {
+			continue
+		}
+		unknownCriticalOpts = append(unknownCriticalOpts, opt.ID)
+		lastUnknownCriticalOpt = opt.ID
+	}
+	return unknownCriticalOpts
+}
+
+func FormatUnknownCriticalOptionsDiagnostic(unknownCriticalOpts []message.OptionID) string {
+	parts := make([]string, 0, len(unknownCriticalOpts))
+	for _, opt := range unknownCriticalOpts {
+		parts = append(parts, strconv.FormatUint(uint64(opt), 10))
+	}
+	return "unknown critical option(s): " + strings.Join(parts, ",")
+}

--- a/net/client/criticalOptions_test.go
+++ b/net/client/criticalOptions_test.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUnknownCriticalOptions(t *testing.T) {
+	options := message.Options{
+		{ID: message.URIPath, Value: []byte("store")},
+		{ID: 12, Value: []byte{0x01}},
+		{ID: 13, Value: []byte{0x01}},
+		{ID: 13, Value: []byte{0x02}},
+		{ID: 99, Value: []byte{0x01}},
+		{ID: 100, Value: []byte{0x01}},
+	}
+
+	unknownCriticalOpts := GetUnknownCriticalOptions(options)
+	require.Equal(t, []message.OptionID{13, 99}, unknownCriticalOpts)
+}
+
+func TestFormatUnknownCriticalOptionsDiagnostic(t *testing.T) {
+	diagnostic := FormatUnknownCriticalOptionsDiagnostic([]message.OptionID{13, 99})
+	require.Equal(t, "unknown critical option(s): 13,99", diagnostic)
+}

--- a/tcp/client/session.go
+++ b/tcp/client/session.go
@@ -13,6 +13,7 @@ import (
 	"github.com/plgd-dev/go-coap/v3/message/codes"
 	"github.com/plgd-dev/go-coap/v3/message/pool"
 	coapNet "github.com/plgd-dev/go-coap/v3/net"
+	netClient "github.com/plgd-dev/go-coap/v3/net/client"
 	"github.com/plgd-dev/go-coap/v3/net/monitor/inactivity"
 	"github.com/plgd-dev/go-coap/v3/pkg/math"
 	"github.com/plgd-dev/go-coap/v3/tcp/coder"
@@ -162,39 +163,103 @@ func seekBufferToNextMessage(buffer *bytes.Buffer, msgSize int) *bytes.Buffer {
 	return buffer
 }
 
+func (s *Session) decodeMessageFromBuffer(buffer *bytes.Buffer) (*pool.Message, bool, error) {
+	var header coder.MessageHeader
+	_, err := coder.DefaultCoder.DecodeHeader(buffer.Bytes(), &header)
+	if errors.Is(err, message.ErrShortRead) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("cannot decode header: %w", err)
+	}
+	if header.MessageLength > s.maxMessageSize {
+		return nil, false, fmt.Errorf("max message size(%v) was exceeded %v", s.maxMessageSize, header.MessageLength)
+	}
+	if math.CastTo[uint32](buffer.Len()) < header.MessageLength {
+		return nil, false, nil
+	}
+
+	req := s.messagePool.AcquireMessage(s.Context())
+	read, err := req.UnmarshalWithDecoder(coder.DefaultCoder, buffer.Bytes()[:header.MessageLength])
+	if err != nil {
+		s.messagePool.ReleaseMessage(req)
+		return nil, false, fmt.Errorf("cannot unmarshal with header: %w", err)
+	}
+
+	seekBufferToNextMessage(buffer, read)
+	req.SetSequence(s.Sequence())
+	return req, true, nil
+}
+
+func (s *Session) shouldDropRequest(req *pool.Message) (bool, error) {
+	if req.Code() < codes.GET || req.Code() > codes.DELETE {
+		return false, nil
+	}
+	unknownCriticalOpts := netClient.GetUnknownCriticalOptions(req.Options())
+	if len(unknownCriticalOpts) == 0 {
+		return false, nil
+	}
+	if err := s.respondUnknownCriticalOptions(req, unknownCriticalOpts); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *Session) handleReceivedRequest(cc *Conn, req *pool.Message) (bool, error) {
+	drop, err := s.shouldDropRequest(req)
+	if err != nil {
+		return false, err
+	}
+	if drop {
+		return true, nil
+	}
+
+	drop, err = s.requestMonitor(cc, req)
+	if err != nil {
+		return false, fmt.Errorf("request monitor: %w", err)
+	}
+	if drop {
+		return true, nil
+	}
+
+	s.inactivityMonitor.Notify()
+	cc.pushToReceivedMessageQueue(req)
+	return false, nil
+}
+
 func (s *Session) processBuffer(buffer *bytes.Buffer, cc *Conn) error {
 	for buffer.Len() > 0 {
-		var header coder.MessageHeader
-		_, err := coder.DefaultCoder.DecodeHeader(buffer.Bytes(), &header)
-		if errors.Is(err, message.ErrShortRead) {
-			return nil
-		}
-		if header.MessageLength > s.maxMessageSize {
-			return fmt.Errorf("max message size(%v) was exceeded %v", s.maxMessageSize, header.MessageLength)
-		}
-		if math.CastTo[uint32](buffer.Len()) < header.MessageLength {
-			return nil
-		}
-		req := s.messagePool.AcquireMessage(s.Context())
-		read, err := req.UnmarshalWithDecoder(coder.DefaultCoder, buffer.Bytes()[:header.MessageLength])
+		req, ready, err := s.decodeMessageFromBuffer(buffer)
 		if err != nil {
-			s.messagePool.ReleaseMessage(req)
-			return fmt.Errorf("cannot unmarshal with header: %w", err)
+			return err
 		}
-		buffer = seekBufferToNextMessage(buffer, read)
-		req.SetSequence(s.Sequence())
+		if !ready {
+			return nil
+		}
 
-		drop, err := s.requestMonitor(cc, req)
+		drop, err := s.handleReceivedRequest(cc, req)
 		if err != nil {
 			s.messagePool.ReleaseMessage(req)
-			return fmt.Errorf("request monitor: %w", err)
+			return err
 		}
 		if drop {
 			s.messagePool.ReleaseMessage(req)
-			continue
 		}
-		s.inactivityMonitor.Notify()
-		cc.pushToReceivedMessageQueue(req)
+	}
+	return nil
+}
+
+func (s *Session) respondUnknownCriticalOptions(req *pool.Message, unknownCriticalOpts []message.OptionID) error {
+	resp := s.messagePool.AcquireMessage(req.Context())
+	defer s.messagePool.ReleaseMessage(resp)
+
+	resp.SetCode(codes.BadOption)
+	resp.SetToken(req.Token())
+	resp.SetContentFormat(message.TextPlain)
+	resp.SetBody(bytes.NewReader([]byte(netClient.FormatUnknownCriticalOptionsDiagnostic(unknownCriticalOpts))))
+
+	if err := s.WriteMessage(resp); err != nil {
+		return fmt.Errorf("cannot write bad option response: %w", err)
 	}
 	return nil
 }

--- a/tcp/client_test.go
+++ b/tcp/client_test.go
@@ -25,6 +25,14 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+func bodyToBytes(t *testing.T, r io.Reader) []byte {
+	t.Helper()
+	buf := bytes.NewBuffer(nil)
+	_, err := buf.ReadFrom(r)
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
 func TestConnGet(t *testing.T) {
 	type args struct {
 		path string
@@ -839,6 +847,100 @@ func TestConnRequestMonitorDropRequest(t *testing.T) {
 	_, err = cc.Do(deleteReq)
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestConnRejectUnknownCriticalOptions(t *testing.T) {
+	l, err := coapNet.NewTCPListener("tcp", "")
+	require.NoError(t, err)
+	defer func() {
+		errC := l.Close()
+		require.NoError(t, errC)
+	}()
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	storeMu := sync.Mutex{}
+	storeValue := []byte("atlas-critical-A")
+
+	m := mux.NewRouter()
+	err = m.Handle("/store", mux.HandlerFunc(func(w mux.ResponseWriter, r *mux.Message) {
+		switch r.Code() {
+		case codes.PUT:
+			storeMu.Lock()
+			storeValue = append(storeValue[:0], bodyToBytes(t, r.Body())...)
+			storeMu.Unlock()
+			errS := w.SetResponse(codes.Changed, message.TextPlain, nil)
+			require.NoError(t, errS)
+		case codes.GET:
+			storeMu.Lock()
+			payload := append([]byte(nil), storeValue...)
+			storeMu.Unlock()
+			errS := w.SetResponse(codes.Content, message.TextPlain, bytes.NewReader(payload))
+			require.NoError(t, errS)
+		default:
+			errS := w.SetResponse(codes.MethodNotAllowed, message.TextPlain, nil)
+			require.NoError(t, errS)
+		}
+	}))
+	require.NoError(t, err)
+
+	s := NewServer(options.WithMux(m))
+	defer s.Stop()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errS := s.Serve(l)
+		assert.NoError(t, errS)
+	}()
+
+	cc, err := Dial(l.Addr().String())
+	require.NoError(t, err)
+	defer func() {
+		errC := cc.Close()
+		require.NoError(t, errC)
+	}()
+
+	testCases := []struct {
+		name     string
+		options  message.Options
+		optionID string
+	}{
+		{
+			name: "unknown critical option 99",
+			options: message.Options{
+				{ID: 99, Value: []byte{0x01}},
+			},
+			optionID: "99",
+		},
+		{
+			name: "unknown critical option 13 with content format",
+			options: message.Options{
+				{ID: 13, Value: []byte{0x01}},
+			},
+			optionID: "13",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			setupResp, err := cc.Put(ctx, "/store", message.TextPlain, bytes.NewReader([]byte("atlas-critical-A")))
+			require.NoError(t, err)
+			require.Equal(t, codes.Changed, setupResp.Code())
+
+			probeResp, err := cc.Put(ctx, "/store", message.TextPlain, bytes.NewReader([]byte("atlas-critical-B")), tc.options...)
+			require.NoError(t, err)
+			require.Equal(t, codes.BadOption, probeResp.Code())
+			require.Contains(t, string(bodyToBytes(t, probeResp.Body())), tc.optionID)
+
+			getResp, err := cc.Get(ctx, "/store")
+			require.NoError(t, err)
+			require.Equal(t, codes.Content, getResp.Code())
+			require.Equal(t, []byte("atlas-critical-A"), bodyToBytes(t, getResp.Body()))
+		})
+	}
 }
 
 func TestConnWithCSMExchangeTimeout(t *testing.T) {

--- a/udp/client/conn.go
+++ b/udp/client/conn.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -934,6 +935,14 @@ func (cc *Conn) Process(cm *coapNet.ControlMessage, datagram []byte) error {
 	}
 	req.SetControlMessage(cm)
 	req.SetSequence(cc.Sequence())
+	if req.Type() == message.Confirmable && req.Code() >= codes.GET && req.Code() <= codes.DELETE {
+		unknownCriticalOpts := client.GetUnknownCriticalOptions(req.Options())
+		if len(unknownCriticalOpts) > 0 {
+			err = cc.respondUnknownCriticalOptions(req, unknownCriticalOpts)
+			cc.ReleaseMessage(req)
+			return err
+		}
+	}
 	cc.checkMyMessageID(req)
 	drop, err := cc.requestMonitor(cc, req)
 	if err != nil {
@@ -951,6 +960,26 @@ func (cc *Conn) Process(cm *coapNet.ControlMessage, datagram []byte) error {
 	select {
 	case cc.receivedMessageReader.C() <- req:
 	case <-cc.Context().Done():
+	}
+	return nil
+}
+
+func (cc *Conn) respondUnknownCriticalOptions(req *pool.Message, unknownCriticalOpts []message.OptionID) error {
+	resp := cc.AcquireMessage(req.Context())
+	defer cc.ReleaseMessage(resp)
+
+	resp.SetCode(codes.BadOption)
+	resp.SetToken(req.Token())
+	resp.SetType(message.Acknowledgement)
+	resp.SetMessageID(req.MessageID())
+	resp.SetContentFormat(message.TextPlain)
+	resp.SetBody(bytes.NewReader([]byte(client.FormatUnknownCriticalOptionsDiagnostic(unknownCriticalOpts))))
+
+	cc.setControlInformation(req.ControlMessage())
+	cc.upsertControlInformation(resp)
+
+	if err := cc.session.WriteMessage(resp); err != nil {
+		return fmt.Errorf(errFmtWriteResponse, err)
 	}
 	return nil
 }

--- a/udp/client/conn_test.go
+++ b/udp/client/conn_test.go
@@ -3,6 +3,7 @@ package client_test
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"io"
 	"log"
@@ -20,6 +21,7 @@ import (
 	"github.com/plgd-dev/go-coap/v3/options"
 	"github.com/plgd-dev/go-coap/v3/udp"
 	"github.com/plgd-dev/go-coap/v3/udp/client"
+	"github.com/plgd-dev/go-coap/v3/udp/coder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
@@ -885,6 +887,125 @@ func TestConnPingResponseIsReset(t *testing.T) {
 	require.Equal(t, message.Reset, respType, "CoAP Ping response must be RST per RFC 7252 §4.2")
 	require.Equal(t, codes.Empty, respCode, "CoAP Ping response code must be 0.00 (Empty)")
 	require.Equal(t, uint16(0x04d2), respMID, "CoAP Ping response MID must match request MID")
+}
+
+func TestConnRejectUnknownCriticalOptions(t *testing.T) {
+	l, err := coapNet.NewListenUDP("udp", "")
+	require.NoError(t, err)
+	defer func() {
+		errC := l.Close()
+		require.NoError(t, errC)
+	}()
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	storeMu := sync.Mutex{}
+	storeValue := []byte("atlas-critical-A")
+
+	m := mux.NewRouter()
+	err = m.Handle("/store", mux.HandlerFunc(func(w mux.ResponseWriter, r *mux.Message) {
+		switch r.Code() {
+		case codes.PUT:
+			storeMu.Lock()
+			storeValue = append(storeValue[:0], bodyToBytes(t, r.Body())...)
+			storeMu.Unlock()
+			errS := w.SetResponse(codes.Changed, message.TextPlain, nil)
+			require.NoError(t, errS)
+		case codes.GET:
+			storeMu.Lock()
+			payload := append([]byte(nil), storeValue...)
+			storeMu.Unlock()
+			errS := w.SetResponse(codes.Content, message.TextPlain, bytes.NewReader(payload))
+			require.NoError(t, errS)
+		default:
+			errS := w.SetResponse(codes.MethodNotAllowed, message.TextPlain, nil)
+			require.NoError(t, errS)
+		}
+	}))
+	require.NoError(t, err)
+
+	s := udp.NewServer(options.WithMux(m))
+	defer s.Stop()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errS := s.Serve(l)
+		assert.NoError(t, errS)
+	}()
+
+	cc, err := udp.Dial(l.LocalAddr().String())
+	require.NoError(t, err)
+	defer func() {
+		errC := cc.Close()
+		require.NoError(t, errC)
+	}()
+
+	testCases := []struct {
+		name          string
+		rawRequestHex string
+		optionID      string
+	}{
+		{
+			name:          "unknown critical option 99",
+			rawRequestHex: "43036f1166f302b573746f726510d14a01ff61746c61732d637269746963616c2d42",
+			optionID:      "99",
+		},
+		{
+			name:          "unknown critical option 13 after content format",
+			rawRequestHex: "43036f1166f302b573746f7265101101ff61746c61732d637269746963616c2d42",
+			optionID:      "13",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			setupResp, err := cc.Put(ctx, "/store", message.TextPlain, bytes.NewReader([]byte("atlas-critical-A")))
+			require.NoError(t, err)
+			require.Equal(t, codes.Changed, setupResp.Code())
+
+			rawReq, err := hex.DecodeString(tc.rawRequestHex)
+			require.NoError(t, err)
+			rawResp := sendRawUDPDatagram(t, l.LocalAddr().String(), rawReq)
+
+			decodedResp := pool.NewMessage(context.Background())
+			_, err = decodedResp.UnmarshalWithDecoder(coder.DefaultCoder, rawResp)
+			require.NoError(t, err)
+
+			require.Equal(t, message.Acknowledgement, decodedResp.Type())
+			require.Equal(t, codes.BadOption, decodedResp.Code())
+			require.Contains(t, string(bodyToBytes(t, decodedResp.Body())), tc.optionID)
+
+			getResp, err := cc.Get(ctx, "/store")
+			require.NoError(t, err)
+			require.Equal(t, codes.Content, getResp.Code())
+			require.Equal(t, []byte("atlas-critical-A"), bodyToBytes(t, getResp.Body()))
+		})
+	}
+}
+
+func sendRawUDPDatagram(t *testing.T, target string, rawReq []byte) []byte {
+	t.Helper()
+	conn, err := net.Dial("udp", target)
+	require.NoError(t, err)
+	defer func() {
+		errC := conn.Close()
+		require.NoError(t, errC)
+	}()
+
+	err = conn.SetDeadline(time.Now().Add(2 * time.Second))
+	require.NoError(t, err)
+
+	_, err = conn.Write(rawReq)
+	require.NoError(t, err)
+
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	require.NoError(t, err)
+	return append([]byte(nil), buf[:n]...)
 }
 
 func TestConnRequestMonitorCloseConnection(t *testing.T) {


### PR DESCRIPTION
Fixes #666

Enforce RFC 7252 behavior for unrecognized critical options by returning 4.02 Bad Option before application handlers are invoked, preventing unintended resource mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of unknown critical CoAP options and automatic request rejection with a `Bad Option` response.
  * Applies to both TCP and UDP; UDP responds with an acknowledgement and text/plain diagnostic listing the unknown option IDs.
* **Tests**
  * Added unit tests covering unknown-option detection and diagnostic formatting.
  * Added TCP and UDP integration tests verifying rejected requests return `Bad Option` and do not modify stored data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->