### PR TITLE
fix(udp): keep peer session on malformed packets and RST malformed CON

### DIFF
--- a/udp/client/conn.go
+++ b/udp/client/conn.go
@@ -48,6 +48,25 @@ type InactivityMonitor interface {
 	CheckInactivity(now time.Time, cc *Conn)
 }
 
+// MalformedMessageError contains best-effort CoAP header metadata extracted
+// during decode failure. HasHeader indicates whether Type and MessageID are
+// valid and can be used by callers for protocol-level decisions.
+type MalformedMessageError struct {
+	Type           message.Type
+	MessageID      int32
+	HasHeader      bool
+	InvalidVersion bool
+	Err            error
+}
+
+func (e *MalformedMessageError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *MalformedMessageError) Unwrap() error {
+	return e.Err
+}
+
 type Session interface {
 	Context() context.Context
 	Close() error
@@ -929,8 +948,17 @@ func (cc *Conn) Process(cm *coapNet.ControlMessage, datagram []byte) error {
 	req := cc.AcquireMessage(cc.Context())
 	_, err := req.UnmarshalWithDecoder(coder.DefaultCoder, datagram)
 	if err != nil {
+		malformedErr := &MalformedMessageError{Err: err}
+		if len(datagram) >= 1 && datagram[0]>>6 != 1 {
+			malformedErr.InvalidVersion = true
+		}
+		if len(datagram) >= 4 && !malformedErr.InvalidVersion {
+			malformedErr.HasHeader = true
+			malformedErr.Type = req.Type()
+			malformedErr.MessageID = req.MessageID()
+		}
 		cc.ReleaseMessage(req)
-		return err
+		return malformedErr
 	}
 	req.SetControlMessage(cm)
 	req.SetSequence(cc.Sequence())

--- a/udp/coder/coder.go
+++ b/udp/coder/coder.go
@@ -105,13 +105,19 @@ func (c *Coder) Decode(data []byte, m *message.Message) (int, error) {
 	}
 
 	typ := message.Type((data[0] >> 4) & 0x3)
+	code := codes.Code(data[1])
+	messageID := binary.BigEndian.Uint16(data[2:4])
+	m.Type = typ
+	m.Code = code
+	m.MessageID = int32(messageID)
+	m.Token = nil
+	m.Payload = nil
+	m.Options = m.Options[:0]
+
 	tokenLen := int(data[0] & 0xf)
 	if tokenLen > 8 {
 		return -1, message.ErrInvalidTokenLen
 	}
-
-	code := codes.Code(data[1])
-	messageID := binary.BigEndian.Uint16(data[2:4])
 	data = data[4:]
 	if len(data) < tokenLen {
 		return -1, ErrMessageTruncated
@@ -133,10 +139,7 @@ func (c *Coder) Decode(data []byte, m *message.Message) (int, error) {
 	}
 
 	m.Payload = data
-	m.Code = code
 	m.Token = token
-	m.Type = typ
-	m.MessageID = int32(messageID)
 
 	return size, nil
 }

--- a/udp/server/server.go
+++ b/udp/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
@@ -16,6 +17,7 @@ import (
 	"github.com/plgd-dev/go-coap/v3/net/responsewriter"
 	coapSync "github.com/plgd-dev/go-coap/v3/pkg/sync"
 	"github.com/plgd-dev/go-coap/v3/udp/client"
+	"github.com/plgd-dev/go-coap/v3/udp/coder"
 )
 
 type Server struct {
@@ -117,6 +119,67 @@ func (s *Server) shouldPropagateError(err error) bool {
 	return s.ctx.Err() == nil && !coapNet.IsCancelOrCloseError(err)
 }
 
+func isMalformedMessageError(err error) bool {
+	return errors.Is(err, coder.ErrMessageTruncated) ||
+		errors.Is(err, coder.ErrMessageInvalidVersion) ||
+		errors.Is(err, message.ErrInvalidTokenLen) ||
+		errors.Is(err, message.ErrInvalidOptionHeaderExt) ||
+		errors.Is(err, message.ErrOptionTruncated) ||
+		errors.Is(err, message.ErrOptionUnexpectedExtendMarker) ||
+		errors.Is(err, message.ErrOptionsTooSmall) ||
+		errors.Is(err, message.ErrInvalidEncoding)
+}
+
+func makeResetDatagram(mid int32) []byte {
+	d := make([]byte, 4)
+	// Ver=1, Type=RST(3), TKL=0
+	d[0] = 0x70
+	// Code=0.00 Empty
+	d[1] = 0x00
+	binary.BigEndian.PutUint16(d[2:4], uint16(mid))
+	return d
+}
+
+func (s *Server) maybeRejectMalformedConfirmable(l *coapNet.UDPConn, cc *client.Conn, cm *coapNet.ControlMessage, processErr error) {
+	if !isMalformedMessageError(processErr) {
+		return
+	}
+	var malformedErr *client.MalformedMessageError
+	if !errors.As(processErr, &malformedErr) {
+		return
+	}
+	if malformedErr.InvalidVersion {
+		// RFC 7252 §3: unknown CoAP versions MUST be silently ignored.
+		return
+	}
+	if !malformedErr.HasHeader {
+		return
+	}
+	if malformedErr.Type != message.Confirmable {
+		return
+	}
+	if !message.ValidateMID(malformedErr.MessageID) {
+		return
+	}
+
+	raddr, ok := cc.RemoteAddr().(*net.UDPAddr)
+	if !ok || raddr == nil {
+		return
+	}
+
+	resetDatagram := makeResetDatagram(malformedErr.MessageID)
+	writeOpts := []coapNet.UDPWriteOption{coapNet.WithContext(s.ctx), coapNet.WithRemoteAddr(raddr)}
+	if cm != nil {
+		writeOpts = append(writeOpts, coapNet.WithControlMessage(&coapNet.ControlMessage{
+			IfIndex: cm.GetIfIndex(),
+			Src:     cm.Dst,
+		}))
+	}
+	if err := l.WriteWithOptions(resetDatagram, writeOpts...); err != nil {
+		s.cfg.Errors(fmt.Errorf("%v: cannot send reset for malformed confirmable packet: %w", cc.RemoteAddr(), err))
+	}
+}
+
 func (s *Server) Serve(l *coapNet.UDPConn) error {
 	if s.cfg.BlockwiseSZX > blockwise.SZX1024 {
 		return errors.New("invalid blockwiseSZX")
@@ -174,8 +237,9 @@ func (s *Server) Serve(l *coapNet.UDPConn) error {
 		}
 		err = cc.Process(cm, buf)
 		if err != nil {
-			s.closeConnection(cc)
-			s.cfg.Errors(fmt.Errorf("%v: cannot process packet: %w", cc.RemoteAddr(), err))
+			s.maybeRejectMalformedConfirmable(l, cc, cm, err)
+			s.cfg.Errors(fmt.Errorf("%v: dropping malformed packet: %w", cc.RemoteAddr(), err))
+			continue
 		}
 	}
 }

--- a/udp/server/server.go
+++ b/udp/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/plgd-dev/go-coap/v3/net/blockwise"
 	"github.com/plgd-dev/go-coap/v3/net/monitor/inactivity"
 	"github.com/plgd-dev/go-coap/v3/net/responsewriter"
+	pkgMath "github.com/plgd-dev/go-coap/v3/pkg/math"
 	coapSync "github.com/plgd-dev/go-coap/v3/pkg/sync"
 	"github.com/plgd-dev/go-coap/v3/udp/client"
 	"github.com/plgd-dev/go-coap/v3/udp/coder"
@@ -130,14 +131,21 @@ func isMalformedMessageError(err error) bool {
 		errors.Is(err, message.ErrInvalidEncoding)
 }
 
-func makeResetDatagram(mid int32) []byte {
+func makeResetDatagram(mid int32) ([]byte, error) {
+	if !message.ValidateMID(mid) {
+		return nil, fmt.Errorf("invalid reset mid: %v", mid)
+	}
 	d := make([]byte, 4)
 	// Ver=1, Type=RST(3), TKL=0
 	d[0] = 0x70
 	// Code=0.00 Empty
 	d[1] = 0x00
-	binary.BigEndian.PutUint16(d[2:4], uint16(mid))
-	return d
+	midU16, err := pkgMath.SafeCastTo[uint16](mid)
+	if err != nil {
+		return nil, fmt.Errorf("invalid reset mid: %w", err)
+	}
+	binary.BigEndian.PutUint16(d[2:4], midU16)
+	return d, nil
 }
 
 func (s *Server) maybeRejectMalformedConfirmable(l *coapNet.UDPConn, cc *client.Conn, cm *coapNet.ControlMessage, processErr error) {
@@ -167,7 +175,11 @@ func (s *Server) maybeRejectMalformedConfirmable(l *coapNet.UDPConn, cc *client.
 		return
 	}
 
-	resetDatagram := makeResetDatagram(malformedErr.MessageID)
+	resetDatagram, err := makeResetDatagram(malformedErr.MessageID)
+	if err != nil {
+		s.cfg.Errors(fmt.Errorf("%v: cannot build reset for malformed confirmable packet: %w", cc.RemoteAddr(), err))
+		return
+	}
 	writeOpts := []coapNet.UDPWriteOption{coapNet.WithContext(s.ctx), coapNet.WithRemoteAddr(raddr)}
 	if cm != nil {
 		writeOpts = append(writeOpts, coapNet.WithControlMessage(&coapNet.ControlMessage{
@@ -178,6 +190,62 @@ func (s *Server) maybeRejectMalformedConfirmable(l *coapNet.UDPConn, cc *client.
 	if err := l.WriteWithOptions(resetDatagram, writeOpts...); err != nil {
 		s.cfg.Errors(fmt.Errorf("%v: cannot send reset for malformed confirmable packet: %w", cc.RemoteAddr(), err))
 	}
+}
+
+func isUnknownVersionError(err error) bool {
+	var malformedErr *client.MalformedMessageError
+	if errors.As(err, &malformedErr) {
+		return malformedErr.InvalidVersion
+	}
+	return errors.Is(err, coder.ErrMessageInvalidVersion)
+}
+
+type incomingDatagram struct {
+	buf   []byte
+	raddr *net.UDPAddr
+	cm    *coapNet.ControlMessage
+}
+
+func (s *Server) readIncomingDatagram(l *coapNet.UDPConn, buf []byte) (incomingDatagram, error) {
+	var raddr *net.UDPAddr
+	var cm *coapNet.ControlMessage
+	n, err := l.ReadWithOptions(buf, coapNet.WithContext(s.ctx), coapNet.WithGetControlMessage(&cm), coapNet.WithGetRemoteAddr(&raddr))
+	if err != nil {
+		return incomingDatagram{}, err
+	}
+	return incomingDatagram{
+		buf:   buf[:n],
+		raddr: raddr,
+		cm:    cm,
+	}, nil
+}
+
+func (s *Server) resolvePacketLocalAddr(l *coapNet.UDPConn, cm *coapNet.ControlMessage) (*net.UDPAddr, error) {
+	// UDPConn.LocalAddr() only takes into account the address it is bound to.
+	// In the case of a wildcard address, the actual destination address is in the control message.
+	// On server-initiated exchanges, listener's LocalAddr can be used as the client has no assumptions of the source.
+	laddr, err := s.getListenerLocalAddr(l)
+	if err != nil {
+		return nil, err
+	}
+	if cm != nil && len(cm.Dst) > 0 && !cm.Dst.IsMulticast() {
+		laddr.IP = cm.Dst
+	}
+	return laddr, nil
+}
+
+func (s *Server) handleProcessError(l *coapNet.UDPConn, cc *client.Conn, cm *coapNet.ControlMessage, err error) {
+	if isMalformedMessageError(err) {
+		s.maybeRejectMalformedConfirmable(l, cc, cm, err)
+		if isUnknownVersionError(err) {
+			// RFC 7252 §3: unknown CoAP versions MUST be silently ignored.
+			return
+		}
+		s.cfg.Errors(fmt.Errorf("%v: dropping malformed packet: %w", cc.RemoteAddr(), err))
+		return
+	}
+	s.closeConnection(cc)
+	s.cfg.Errors(fmt.Errorf("%v: cannot process packet: %w", cc.RemoteAddr(), err))
 }
 
 func (s *Server) Serve(l *coapNet.UDPConn) error {
@@ -207,38 +275,27 @@ func (s *Server) Serve(l *coapNet.UDPConn) error {
 	})
 
 	for {
-		buf := m
-		var raddr *net.UDPAddr
-		var cm *coapNet.ControlMessage
-		n, err := l.ReadWithOptions(buf, coapNet.WithContext(s.ctx), coapNet.WithGetControlMessage(&cm), coapNet.WithGetRemoteAddr(&raddr))
+		packet, err := s.readIncomingDatagram(l, m)
 		if err != nil {
 			if !s.shouldPropagateError(err) {
 				return nil
 			}
 			return err
 		}
-		buf = buf[:n]
 
-		// UDPConn.LocalAddr() only takes into account the address it is bound to.
-		// In the case of a wildcard address, the actual destination address is in the control message.
-		// On server-initiated exchanges, listener's LocalAddr can be used as the client has no assumptions of the source.
-		laddr, err := s.getListenerLocalAddr(l)
+		laddr, err := s.resolvePacketLocalAddr(l, packet.cm)
 		if err != nil {
 			return err
 		}
-		if cm != nil && len(cm.Dst) > 0 && !cm.Dst.IsMulticast() {
-			laddr.IP = cm.Dst
-		}
 
-		cc, err := s.getConn(l, raddr, laddr, true)
+		cc, err := s.getConn(l, packet.raddr, laddr, true)
 		if err != nil {
-			s.cfg.Errors(fmt.Errorf("%v: cannot get client connection: %w", raddr, err))
+			s.cfg.Errors(fmt.Errorf("%v: cannot get client connection: %w", packet.raddr, err))
 			continue
 		}
-		err = cc.Process(cm, buf)
+		err = cc.Process(packet.cm, packet.buf)
 		if err != nil {
-			s.maybeRejectMalformedConfirmable(l, cc, cm, err)
-			s.cfg.Errors(fmt.Errorf("%v: dropping malformed packet: %w", cc.RemoteAddr(), err))
+			s.handleProcessError(l, cc, packet.cm, err)
 			continue
 		}
 	}

--- a/udp/server_test.go
+++ b/udp/server_test.go
@@ -29,6 +29,29 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+func sendAndReadUDPDatagram(t *testing.T, c *net.UDPConn, req []byte) []byte {
+	t.Helper()
+	err := c.SetDeadline(time.Now().Add(time.Second))
+	require.NoError(t, err)
+	_, err = c.Write(req)
+	require.NoError(t, err)
+
+	buf := make([]byte, 1500)
+	n, err := c.Read(buf)
+	require.NoError(t, err)
+	return buf[:n]
+}
+
+func requireResetWithMID(t *testing.T, datagram []byte, mid uint16) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(datagram), 4)
+	first := datagram[0]
+	require.Equal(t, uint8(1), first>>6, "response version must be 1")
+	require.Equal(t, message.Reset, message.Type((first>>4)&0x3), "response type must be RST")
+	require.Equal(t, uint8(0), datagram[1], "response code must be Empty")
+	require.Equal(t, mid, binary.BigEndian.Uint16(datagram[2:4]), "response MID must match request MID")
+}
+
 type mcastreceiver struct {
 	msgs []*pool.Message
 	sync.Mutex
@@ -234,6 +257,59 @@ func TestServerDiscover(t *testing.T) {
 			require.Equal(t, codes.BadRequest, got[0].Code())
 		})
 	}
+}
+
+func TestServerRejectsMalformedConfirmableWithoutTearingDownConnection(t *testing.T) {
+	ld, err := coapNet.NewListenUDP("udp4", "")
+	require.NoError(t, err)
+	defer func() {
+		errC := ld.Close()
+		require.NoError(t, errC)
+	}()
+
+	var newConnCount atomic.Int32
+	s := udp.NewServer(options.WithOnNewConn(func(*client.Conn) {
+		newConnCount.Inc()
+	}))
+	t.Cleanup(func() {
+		s.Stop()
+	})
+
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		wg.Wait()
+	})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		errS := s.Serve(ld)
+		assert.NoError(t, errS)
+	}()
+
+	serverAddr, ok := ld.LocalAddr().(*net.UDPAddr)
+	require.True(t, ok)
+	cli, err := net.DialUDP("udp4", nil, serverAddr)
+	require.NoError(t, err)
+	defer func() {
+		errC := cli.Close()
+		require.NoError(t, errC)
+	}()
+
+	// Create the per-peer connection with a valid ping and verify RST response.
+	pong := sendAndReadUDPDatagram(t, cli, []byte{0x40, 0x00, 0x11, 0x11})
+	requireResetWithMID(t, pong, 0x1111)
+	require.Eventually(t, func() bool {
+		return newConnCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	// Malformed CON: version=1, type=CON, TKL=9 (invalid), MID=0x2222.
+	rst := sendAndReadUDPDatagram(t, cli, []byte{0x49, 0x01, 0x22, 0x22})
+	requireResetWithMID(t, rst, 0x2222)
+
+	// Verify the same per-peer connection remains alive and is reused.
+	pong = sendAndReadUDPDatagram(t, cli, []byte{0x40, 0x00, 0x33, 0x33})
+	requireResetWithMID(t, pong, 0x3333)
+	require.Equal(t, int32(1), newConnCount.Load(), "malformed datagram must not recreate per-peer connection")
 }
 
 func TestServerCleanUpConns(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/plgd-dev/go-coap/issues/664 point 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Fixes `#664` point 1**
  * Improved handling of malformed UDP/CoAP traffic: confirmable packets now receive a proper CoAP Reset response (with the correct Message ID) instead of tearing down the connection.
* **Bug Fixes**
  * Enhanced decode failure reporting with more useful header/context details.
  * Better preserves existing per-peer UDP connections when invalid packets are received.
* **Tests**
  * Added coverage to verify malformed confirmables are rejected with a Reset while keeping the connection intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->